### PR TITLE
Limit LogEscape string size

### DIFF
--- a/src/mp/util.cpp
+++ b/src/mp/util.cpp
@@ -31,8 +31,10 @@ std::string ThreadName(const char* exe_name)
 
 std::string LogEscape(const kj::StringTree& string)
 {
+    const int MAX_SIZE = 1000;
     std::string result;
     string.visit([&](const kj::ArrayPtr<const char>& piece) {
+        if (result.size() > MAX_SIZE) return;
         for (char c : piece) {
             if ('c' == '\\') {
                 result.append("\\\\");
@@ -42,6 +44,10 @@ std::string LogEscape(const kj::StringTree& string)
                 result.append(escape);
             } else {
                 result.push_back(c);
+            }
+            if (result.size() > MAX_SIZE) {
+                result += "...";
+                break;
             }
         }
     });


### PR DESCRIPTION
Try to avoid massive debug log file sizes, and travis MemoryError in
https://github.com/bitcoin/bitcoin/pull/10102, https://travis-ci.org/bitcoin/bitcoin/jobs/558040257:

```
TestFramework (ERROR): Unexpected exception caught during testing
Traceback (most recent call last):
  File "/home/travis/build/bitcoin/bitcoin/build/bitcoin-x86_64-unknown-linux-gnu/test/functional/test_framework/test_framework.py", line 193, in main
    self.run_test()
  File "/home/travis/build/bitcoin/bitcoin/build/bitcoin-x86_64-unknown-linux-gnu/test/functional/feature_block.py", line 1222, in run_test
    self.send_blocks(blocks, True, timeout=1500)
  File "/home/travis/build/bitcoin/bitcoin/build/bitcoin-x86_64-unknown-linux-gnu/test/functional/feature_block.py", line 1373, in send_blocks
    self.nodes[0].p2p.send_blocks_and_test(blocks, self.nodes[0], success=success, reject_reason=reject_reason, force_send=force_send, timeout=timeout, expect_disconnect=reconnect)
  File "/home/travis/build/bitcoin/bitcoin/build/bitcoin-x86_64-unknown-linux-gnu/test/functional/test_framework/mininode.py", line 553, in send_blocks_and_test
    assert node.getbestblockhash() != blocks[-1].hash
  File "/usr/lib/python3.6/contextlib.py", line 88, in __exit__
    next(self.gen)
  File "/home/travis/build/bitcoin/bitcoin/build/bitcoin-x86_64-unknown-linux-gnu/test/functional/test_framework/test_node.py", line 318, in assert_debug_log
    log = dl.read()
  File "/usr/lib/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
MemoryError
```