### PR TITLE
Add ProxyClientBase destroy_connection option

### DIFF
--- a/include/mp/proxy.h
+++ b/include/mp/proxy.h
@@ -48,7 +48,7 @@ public:
     using Interface = Interface_;
     using Impl = Impl_;
 
-    ProxyClientBase(typename Interface::Client client, Connection& connection);
+    ProxyClientBase(typename Interface::Client client, Connection* connection, bool destroy_connection);
     ~ProxyClientBase() noexcept;
 
     // Methods called during client construction/destruction that can optionally
@@ -60,7 +60,9 @@ public:
 
     typename Interface::Client m_client;
     Connection* m_connection;
-    CleanupIt m_cleanup;
+    bool m_destroy_connection;
+    CleanupIt m_cleanup; //!< Pointer to self-cleanup callback registered to handle connection object getting destroyed
+                         //!< before this client object.
 };
 
 //! Customizable (through template specialization) base class used in generated ProxyClient implementations from

--- a/src/mp/test/test.cpp
+++ b/src/mp/test/test.cpp
@@ -26,7 +26,7 @@ KJ_TEST("Call FooInterface methods")
         auto connection_client = std::make_unique<Connection>(loop, kj::mv(pipe.ends[0]), true);
         auto foo_client = std::make_unique<ProxyClient<messages::FooInterface>>(
             connection_client->m_rpc_system.bootstrap(ServerVatId().vat_id).castAs<messages::FooInterface>(),
-            *connection_client);
+            connection_client.get(), /* destroy_connection= */ false);
         foo_promise.set_value(std::move(foo_client));
         disconnect_client = [&] { loop.sync([&] { connection_client.reset(); }); };
 
@@ -34,7 +34,7 @@ KJ_TEST("Call FooInterface methods")
             auto foo_server = kj::heap<ProxyServer<messages::FooInterface>>(new FooImplementation, true, connection);
             return capnp::Capability::Client(kj::mv(foo_server));
         });
-        loop.m_task_set->add(connection_server->m_network.onDisconnect().then([&] { connection_server.reset(); }));
+        connection_server->onDisconnect([&] { connection_server.reset(); });
         loop.loop();
     });
 


### PR DESCRIPTION
Give ProxyClientBase class the ability to delete the Connection object in its destructor. This avoids the need for separate [`ShutdownLoop`](https://github.com/ryanofsky/bitcoin/blob/pr/ipc/src/interfaces/capnp/ipc.cpp#L50-L65) close hook in https://github.com/bitcoin/bitcoin/pull/10102.

This exposed a race condition which required adding a TaskSet member to Connection objects to fix. With the previous ShutdownLoop approach, the client capability handle would be freed in the event loop thread, then there would be a switch back to the client thread, then there would be another switch back to the event loop thread to free the connection, most likely after the event loop thread had a chance to process new events. With the new approach, the client capability handle and Connection object are destroyed back to back in the event loop thread, causing the onDisconnect handler to fire when it previously didn't, after the Connection object had already been destroyed, and resulting in a double deletion of the Connection pointer. The race is fixed here by using separate kj::TaskSet objects for each connection, so onDisconnect events are now cancelled as Connection objects are destroyed.