### PR TITLE
Remove #include <syscall.h> to avoid mac os build error

### DIFF
--- a/src/mp/util.cpp
+++ b/src/mp/util.cpp
@@ -13,8 +13,11 @@
 #include <sys/types.h>
 #include <sys/un.h>
 #include <sys/wait.h>
-#include <syscall.h>
 #include <unistd.h>
+
+#if __linux__
+#include <syscall.h>
+#endif
 
 namespace mp {
 namespace {


### PR DESCRIPTION
Issue was found by hugohn in https://github.com/chaincodelabs/libmultiprocess/issues/5#issuecomment-518802181