### PR TITLE
Replace ProxyServer connection pointer with reference

### DIFF
--- a/include/mp/proxy.h
+++ b/include/mp/proxy.h
@@ -101,11 +101,7 @@ public:
      * appropriate times depending on semantics of the particular method being
      * wrapped. */
     bool m_owned;
-    /**
-     * Connection is a pointer rather than a reference because for the Init
-     * server, the server object needs to be created before the connection.
-     */
-    Connection* m_connection;
+    Connection& m_connection;
 };
 
 //! Customizable (through template specialization) base class used in generated ProxyServer implementations from

--- a/src/mp/proxy.cpp
+++ b/src/mp/proxy.cpp
@@ -236,17 +236,6 @@ void EventLoop::startAsyncThread(std::unique_lock<std::mutex>& lock)
     }
 }
 
-void AddClient(EventLoop& loop)
-{
-    std::unique_lock<std::mutex> lock(loop.m_mutex);
-    loop.addClient(lock);
-}
-void RemoveClient(EventLoop& loop)
-{
-    std::unique_lock<std::mutex> lock(loop.m_mutex);
-    loop.removeClient(lock);
-}
-
 ProxyServer<Thread>::ProxyServer(ThreadContext& thread_context, std::thread&& thread)
     : m_thread_context(thread_context), m_thread(std::move(thread))
 {

--- a/src/mp/test/test.cpp
+++ b/src/mp/test/test.cpp
@@ -23,7 +23,7 @@ KJ_TEST("Call FooInterface methods")
         EventLoop loop("mptest", [](bool raise, const std::string& log) {});
         auto pipe = loop.m_io_context.provider->newTwoWayPipe();
 
-        auto connection_client = std::make_unique<Connection>(loop, kj::mv(pipe.ends[0]), true);
+        auto connection_client = std::make_unique<Connection>(loop, kj::mv(pipe.ends[0]));
         auto foo_client = std::make_unique<ProxyClient<messages::FooInterface>>(
             connection_client->m_rpc_system.bootstrap(ServerVatId().vat_id).castAs<messages::FooInterface>(),
             connection_client.get(), /* destroy_connection= */ false);


### PR DESCRIPTION
This is just cleanup. Using a pointer instead of reference used to be necessary
before the Connection constructor took a make_server option. But now there is
no reason to have a pointer and unnecessary null handling.

Also, Connection add_client option and AddClient RemoveClient ServeStream
wrapper functions are removed. These were originally meant to simplify usages
but cause more trouble than they are worth.