### PR TITLE
Add Eventloop void* context pointer

### DIFF
--- a/include/mp/proxy-io.h
+++ b/include/mp/proxy-io.h
@@ -119,7 +119,7 @@ class EventLoop
 {
 public:
     //! Construct event loop object.
-    EventLoop(const char* exe_name, LogFn log_fn);
+    EventLoop(const char* exe_name, LogFn log_fn, void* context = nullptr);
     ~EventLoop();
 
     //! Run event loop. Does not return until shutdown. This should only be
@@ -204,7 +204,11 @@ public:
     //! List of connections.
     std::list<Connection> m_incoming_connections;
 
+    //! External logging callback.
     LogFn m_log_fn;
+
+    //! External context pointer.
+    void* m_context;
 };
 
 //! Single element task queue used to handle recursive capnp calls. (If server

--- a/src/mp/proxy.cpp
+++ b/src/mp/proxy.cpp
@@ -123,8 +123,8 @@ void Connection::addAsyncCleanup(std::function<void()> fn)
     m_async_cleanup_fns.emplace(m_async_cleanup_fns.begin(), std::move(fn));
 }
 
-EventLoop::EventLoop(const char* exe_name, LogFn log_fn)
-    : m_exe_name(exe_name), m_io_context(kj::setupAsyncIo()), m_log_fn(std::move(log_fn))
+EventLoop::EventLoop(const char* exe_name, LogFn log_fn, void* context)
+    : m_exe_name(exe_name), m_io_context(kj::setupAsyncIo()), m_log_fn(std::move(log_fn)), m_context(context)
 {
     int fds[2];
     KJ_SYSCALL(socketpair(AF_UNIX, SOCK_STREAM, 0, fds));


### PR DESCRIPTION
Useful to avoid having to use globals to pass information to custom ProxyClient,
ProxyServer overloads.