### PR TITLE
Add simpler ServeStream function

### DIFF
--- a/src/mp/proxy.cpp
+++ b/src/mp/proxy.cpp
@@ -305,23 +305,4 @@ std::string LongThreadName(const char* exe_name)
     return g_thread_context.thread_name.empty() ? ThreadName(exe_name) : g_thread_context.thread_name;
 }
 
-void ServeStream(EventLoop& loop,
-    kj::Own<kj::AsyncIoStream>&& stream,
-    std::function<capnp::Capability::Client(Connection&)> make_server)
-{
-    loop.m_incoming_connections.emplace_front(loop, kj::mv(stream), make_server);
-    auto it = loop.m_incoming_connections.begin();
-    it->onDisconnect([&loop, it] {
-        loop.log() << "IPC server: socket disconnected.";
-        loop.m_incoming_connections.erase(it);
-    });
-}
-
-void ServeStream(EventLoop& loop, int fd, std::function<capnp::Capability::Client(Connection&)> make_server)
-{
-    ServeStream(loop,
-        loop.m_io_context.lowLevelProvider->wrapSocketFd(fd, kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP),
-        std::move(make_server));
-}
-
 } // namespace mp


### PR DESCRIPTION
Be more consistent with ConnectStream and just require Init message type
instead of ProxyServer constructing callback, and file descriptor number
instead of a stream object.