### PR TITLE
Fix compilation of foo.h: include <string>

### DIFF
--- a/src/mp/test/foo.h
+++ b/src/mp/test/foo.h
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace mp {


### PR DESCRIPTION
std::string is used inside foo.h but it forgot to include the
corresponding header:

```
[ 53%] Building CXX object CMakeFiles/mptest.dir/src/mp/test/foo.capnp.proxy-server.c++.o
/usr/bin/c++   -I/usr/local/lib/cmake/CapnProto/../../../include -IBUILD/libmultiprocess/include -ISOURCE/libmultiprocess/include -ISOURCE/libmultiprocess/src -IBUILD/libmultiprocess/src -isystem /usr/local/include -D_THREAD_SAFE -pthread -std=gnu++14 -o CMakeFiles/mptest.dir/src/mp/test/foo.capnp.proxy-server.c++.o -c BUILD/libmultiprocess/src/mp/test/foo.capnp.proxy-server.c++
In file included from BUILD/libmultiprocess/src/mp/test/foo.capnp.proxy-server.c++:3:
In file included from BUILD/libmultiprocess/src/mp/test/foo.capnp.proxy-types.h:6:
In file included from BUILD/libmultiprocess/src/mp/test/foo.capnp.proxy.h:7:
SOURCE/libmultiprocess/src/mp/test/foo.h:17:17: error: implicit
      instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>,
      std::__1::allocator<char> >'
    std::string name;
                ^
/usr/include/c++/v1/iosfwd:210:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;
                               ^
1 error generated.
...

$ c++ --version
FreeBSD clang version 8.0.1 (tags/RELEASE_801/final 366581) (based on LLVM 8.0.1)
Target: x86_64-unknown-freebsd12.1
Thread model: posix
InstalledDir: /usr/bin
```