### PR TITLE
Handle fork(2) failures

### DIFF
--- a/src/mp/gen.cpp
+++ b/src/mp/gen.cpp
@@ -7,10 +7,12 @@
 
 #include <algorithm>
 #include <capnp/schema-parser.h>
+#include <errno.h>
 #include <fstream>
 #include <map>
 #include <set>
 #include <sstream>
+#include <system_error>
 #include <unistd.h>
 #include <vector>
 
@@ -137,6 +139,9 @@ void Generate(kj::StringPtr src_prefix,
     args.emplace_back("--output=" capnp_PREFIX "/bin/capnpc-c++");
     args.emplace_back(src_file);
     int pid = fork();
+    if (pid == -1) {
+        throw std::system_error(errno, std::system_category(), "fork");
+    }
     if (!pid) {
         mp::ExecProcess(args);
     }

--- a/src/mp/util.cpp
+++ b/src/mp/util.cpp
@@ -4,6 +4,7 @@
 
 #include <mp/util.h>
 
+#include <errno.h>
 #include <kj/array.h>
 #include <pthread.h>
 #include <sstream>
@@ -13,6 +14,7 @@
 #include <sys/types.h>
 #include <sys/un.h>
 #include <sys/wait.h>
+#include <system_error>
 #include <unistd.h>
 
 #if __linux__
@@ -83,6 +85,9 @@ int SpawnProcess(int& pid, FdToArgsFn&& fd_to_args)
     }
 
     pid = fork();
+    if (pid == -1) {
+        throw std::system_error(errno, std::system_category(), "fork");
+    }
     if (close(fds[pid ? 0 : 1]) != 0) {
         throw std::system_error(errno, std::system_category());
     }


### PR DESCRIPTION
Generate() and SpawnProcess() call fork(2) but did not check if it
failed (return -1) and continued execution with possible unexpected
results.

Handle fork(2) failure by throwing an exception.