### PR TITLE
Obliterate Boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ target_include_directories(multiprocess PUBLIC
   ${Boost_INCLUDE_DIR})
 set_target_properties(multiprocess PROPERTIES
     PUBLIC_HEADER "${MP_PUBLIC_HEADERS}"
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES)
 install(TARGETS multiprocess EXPORT Multiprocess ARCHIVE DESTINATION lib PUBLIC_HEADER DESTINATION include/mp)
 
@@ -83,7 +83,7 @@ target_link_libraries(mpgen PRIVATE Threads::Threads)
 target_link_libraries(mpgen PRIVATE multiprocess)
 set_target_properties(mpgen PROPERTIES
     INSTALL_RPATH_USE_LINK_PATH TRUE
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES)
 install(TARGETS mpgen EXPORT Multiprocess RUNTIME DESTINATION bin)
 
@@ -135,7 +135,7 @@ if(BUILD_TESTING AND TARGET CapnProto::kj-test)
   target_link_libraries(mptest PRIVATE Threads::Threads)
   target_link_libraries(mptest PRIVATE multiprocess)
   set_target_properties(mptest PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES)
   add_test(NAME mptest COMMAND mptest)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,6 @@ project("Libmultiprocess" CXX)
 include(CMakePushCheckState)
 include(CTest)
 include(CheckCXXSourceCompiles)
-find_package(Boost)
 find_package(CapnProto REQUIRED)
 find_package(Threads REQUIRED)
 
@@ -64,8 +63,7 @@ target_include_directories(multiprocess PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
   $<INSTALL_INTERFACE:include>
-  ${CAPNP_INCLUDE_DIRECTORY}
-  ${Boost_INCLUDE_DIR})
+  ${CAPNP_INCLUDE_DIRECTORY})
 set_target_properties(multiprocess PROPERTIES
     PUBLIC_HEADER "${MP_PUBLIC_HEADERS}"
     CXX_STANDARD 17

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ _libmultiprocess_ is currently compatible with sandboxing but could add platform
 
 ## Installation
 
-Installation currently requires boost[*] and Cap'n Proto:
+Installation currently requires Cap'n Proto:
 
 ```sh
-apt install libboost-dev libcapnp-dev capnproto
-brew install boost capnp
-dnf install boost-devel capnproto
+apt install libcapnp-dev capnproto
+brew install capnp
+dnf install capnproto
 
 Installation steps are:
 
@@ -46,5 +46,3 @@ make
 make all test
 make install
 ```
-
-[*] The boost dependency should be eliminated; it is solely for `boost::optional`.

--- a/include/mp/proxy-io.h
+++ b/include/mp/proxy-io.h
@@ -10,13 +10,13 @@
 
 #include <mp/proxy.capnp.h>
 
-#include <boost/exception/diagnostic_information.hpp>
-#include <boost/optional/optional.hpp>
 #include <capnp/rpc-twoparty.h>
 
 #include <assert.h>
 #include <functional>
+#include <map>
 #include <memory>
+#include <sstream>
 #include <string>
 
 namespace mp {

--- a/pkgconfig/libmultiprocess.pc.in
+++ b/pkgconfig/libmultiprocess.pc.in
@@ -9,4 +9,4 @@ Description: Multiprocess IPC library
 Version: 0.0
 
 Libs: -L${libdir} -lmultiprocess -L${capnp_prefix}/lib -lcapnp-rpc -lcapnp -lkj-async -lkj -pthread -lpthread
-Cflags: -std=c++14 -I${includedir} -I${capnp_prefix}/include -pthread
+Cflags: -std=c++17 -I${includedir} -I${capnp_prefix}/include -pthread


### PR DESCRIPTION
* While it may be possible to refactor the code in a way that it does
  not use any `optional` types, like in a616312, fb73b81, 138ad67,
  5724a2c, that would be error prone and would require bigger changes.
  Switch from C++14 to C++17 instead and replace `boost::optional` with
  `std::optional`.

* Removing `boost::current_exception_diagnostic_information()` - if the
  caught exception is an instance of `std::exception`, use its `what()`
  method. Otherwise don't provide extra diagnostic information. After
  all `boost::current_exception_diagnostic_information()` would return
  "No diagnostic information available." if it is not `std::exception`
  or `boost::exception`.

* Clean up any mentions of Boost from README.md and CMakeLists.txt.