### PR TITLE
Unify ReadFieldNew / ReadFieldUpdate

### DIFF
--- a/include/mp/util.h
+++ b/include/mp/util.h
@@ -203,7 +203,7 @@ template <typename Exception>
 struct ThrowFn
 {
     template <typename... Params>
-    void operator()(Params&&... params)
+    Exception& operator()(Params&&... params)
     {
         throw Exception(std::forward<Params>(params)...);
     }
@@ -237,6 +237,10 @@ struct Split<index, TypeList<Type, _Second...>, TypeList<_First...>, false>
 //! Type helper giving return type of a callable type.
 template <typename Callable>
 using ResultOf = decltype(std::declval<Callable>()());
+
+//! Substitutue for std::remove_cvref_t
+template <typename T>
+using RemoveCvRef = std::remove_cv_t<std::remove_reference_t<T>>;
 
 //! Type helper abbreviating std::decay.
 template <typename T>


### PR DESCRIPTION
Replace with ReadField wrapper and CustomReadField hook to be consistent with
BuildField / CustomBuildField. This

- Makes it more straightforward pass custom types with symmetric
  CustomReadField / CustomBuildField overloads

- Simplifies debugging and overload resolution, removing hacks that allowed
  ReadFieldNew calls to forward to ReadFieldUpdate calls and vice versa

- Enables more flexibility and efficiency within CustomReadField
  implementations allowing emplacing or updating in the same function based on
  which is simpler or more efficient. Removes a lot of std::enable_if overload
  hacks

- Should allow clientInvoke to use RVO and construct return values in place
  instead of copying or moving. This will allow more types to be for supported
  as IPC return values even if they don't support default construction,
  copying, or moving.

- Improves separation of concerns, avoids need for ReadField callers to know
  whether callee will emplace or update, avoids need for emplace ReadDest
  object to have hardcoded support for map, vector, optional, shared_ptr,
  reference_wrapper types, so they now are implemented the same as any other
  custom type.