### PR TITLE
Fix empty exception values from bad ThrowFn declaration

### DIFF
--- a/include/mp/util.h
+++ b/include/mp/util.h
@@ -203,7 +203,7 @@ template <typename Exception>
 struct ThrowFn
 {
     template <typename... Params>
-    Exception& operator()(Params&&... params)
+    const Exception& operator()(Params&&... params)
     {
         throw Exception(std::forward<Params>(params)...);
     }

--- a/src/mp/test/foo.capnp
+++ b/src/mp/test/foo.capnp
@@ -13,6 +13,7 @@ interface FooInterface $Proxy.wrap("mp::test::FooImplementation") {
     add @0 (a :Int32, b :Int32) -> (result :Int32);
     mapSize @1 (map :List(Pair(Text, Text))) -> (result :Int32);
     pass @2 (arg :FooStruct) -> (result :FooStruct);
+    raise @3 (arg :FooStruct) -> (error :FooStruct $Proxy.exception("mp::test::FooStruct"));
 }
 
 struct FooStruct $Proxy.wrap("mp::test::FooStruct") {

--- a/src/mp/test/foo.h
+++ b/src/mp/test/foo.h
@@ -25,6 +25,7 @@ public:
     int add(int a, int b) { return a + b; }
     int mapSize(const std::map<std::string, std::string>& map) { return map.size(); }
     FooStruct pass(FooStruct foo) { return foo; }
+    void raise(FooStruct foo) { throw foo; }
 };
 
 } // namespace test

--- a/src/mp/test/test.cpp
+++ b/src/mp/test/test.cpp
@@ -46,6 +46,14 @@ KJ_TEST("Call FooInterface methods")
     FooStruct out = foo->pass(in);
     KJ_EXPECT(in.name == out.name);
 
+    FooStruct err;
+    try {
+        foo->raise(in);
+    } catch (const FooStruct& e) {
+        err = e;
+    }
+    KJ_EXPECT(in.name == err.name);
+
     disconnect_client();
     thread.join();
 }


### PR DESCRIPTION
Also extend libmultiprocess unit test with coverage for this case.

Bad non-const ThrowFn declaration was causing ReadDestEmplace to try read
exception values after throwing them instead of before (in
update_fn(construct()) expression when construct() callback throws).

This was causing bitcoin functional tests to fail because JSONRPCError
exceptions caught were just null UniValue objects instead of objects with code
and message fields set.