### PR TITLE
Add shared_ptr callback support

### DIFF
--- a/include/mp/proxy-types.h
+++ b/include/mp/proxy-types.h
@@ -235,6 +235,7 @@ struct ReadDestValue
 
 template <typename LocalType, typename Input, typename ReadDest>
 decltype(auto) CustomReadField(TypeList<std::optional<LocalType>>,
+    Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
     ReadDest&& read_dest)
@@ -256,6 +257,7 @@ decltype(auto) CustomReadField(TypeList<std::optional<LocalType>>,
 
 template <typename LocalType, typename Input, typename ReadDest>
 decltype(auto) CustomReadField(TypeList<std::shared_ptr<LocalType>>,
+    Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
     ReadDest&& read_dest)
@@ -277,6 +279,7 @@ decltype(auto) CustomReadField(TypeList<std::shared_ptr<LocalType>>,
 
 template <typename LocalType, typename Input, typename ReadDest>
 decltype(auto) CustomReadField(TypeList<LocalType*>,
+    Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
     ReadDest&& read_dest)
@@ -290,6 +293,7 @@ decltype(auto) CustomReadField(TypeList<LocalType*>,
 
 template <typename LocalType, typename Input, typename ReadDest>
 decltype(auto) CustomReadField(TypeList<std::shared_ptr<const LocalType>>,
+    Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
     ReadDest&& read_dest)
@@ -309,6 +313,7 @@ decltype(auto) CustomReadField(TypeList<std::shared_ptr<const LocalType>>,
 
 template <typename LocalType, typename Input, typename ReadDest>
 decltype(auto) CustomReadField(TypeList<std::vector<LocalType>>,
+    Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
     ReadDest&& read_dest)
@@ -329,6 +334,7 @@ decltype(auto) CustomReadField(TypeList<std::vector<LocalType>>,
 
 template <typename LocalType, typename Input, typename ReadDest>
 decltype(auto) CustomReadField(TypeList<std::set<LocalType>>,
+    Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
     ReadDest&& read_dest)
@@ -347,6 +353,7 @@ decltype(auto) CustomReadField(TypeList<std::set<LocalType>>,
 
 template <typename KeyLocalType, typename ValueLocalType, typename Input, typename ReadDest>
 decltype(auto) CustomReadField(TypeList<std::map<KeyLocalType, ValueLocalType>>,
+    Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
     ReadDest&& read_dest)
@@ -367,6 +374,7 @@ decltype(auto) CustomReadField(TypeList<std::map<KeyLocalType, ValueLocalType>>,
 
 template <typename KeyLocalType, typename ValueLocalType, typename Input, typename ReadDest>
 decltype(auto) CustomReadField(TypeList<std::pair<KeyLocalType, ValueLocalType>>,
+    Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
     ReadDest&& read_dest)
@@ -391,6 +399,7 @@ decltype(auto) CustomReadField(TypeList<std::pair<KeyLocalType, ValueLocalType>>
 
 template <typename KeyLocalType, typename ValueLocalType, typename Input, typename ReadDest>
 decltype(auto) CustomReadField(TypeList<std::tuple<KeyLocalType, ValueLocalType>>,
+    Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
     ReadDest&& read_dest)
@@ -407,6 +416,7 @@ decltype(auto) CustomReadField(TypeList<std::tuple<KeyLocalType, ValueLocalType>
 
 template <typename LocalType, typename Input, typename ReadDest>
 decltype(auto) CustomReadField(TypeList<LocalType>,
+    Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
     ReadDest&& read_dest,
@@ -417,6 +427,7 @@ decltype(auto) CustomReadField(TypeList<LocalType>,
 
 template <typename LocalType, typename Input, typename ReadDest>
 decltype(auto) CustomReadField(TypeList<LocalType>,
+    Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
     ReadDest&& read_dest,
@@ -431,6 +442,7 @@ decltype(auto) CustomReadField(TypeList<LocalType>,
 
 template <typename LocalType, typename Input, typename ReadDest>
 decltype(auto) CustomReadField(TypeList<LocalType>,
+    Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
     ReadDest&& read_dest,
@@ -443,6 +455,7 @@ decltype(auto) CustomReadField(TypeList<LocalType>,
 
 template <typename Input, typename ReadDest>
 decltype(auto) CustomReadField(TypeList<std::string>,
+    Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
     ReadDest&& read_dest)
@@ -453,6 +466,7 @@ decltype(auto) CustomReadField(TypeList<std::string>,
 
 template <size_t size, typename Input, typename ReadDest>
 decltype(auto) CustomReadField(TypeList<unsigned char[size]>,
+    Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
     ReadDest&& read_dest)
@@ -478,6 +492,7 @@ std::unique_ptr<Impl> CustomMakeProxyClient(InvokeContext& context, typename Int
 
 template <typename LocalType, typename Input, typename ReadDest>
 decltype(auto) CustomReadField(TypeList<std::unique_ptr<LocalType>>,
+    Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
     ReadDest&& read_dest,
@@ -505,6 +520,7 @@ struct ProxyCallFn
 
 template <typename FnR, typename... FnParams, typename Input, typename ReadDest>
 decltype(auto) CustomReadField(TypeList<std::function<FnR(FnParams...)>>,
+    Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
     ReadDest&& read_dest)
@@ -546,6 +562,7 @@ void ReadOne(TypeList<LocalType> param,
 
 template <typename LocalType, typename Input, typename ReadDest>
 decltype(auto) CustomReadField(TypeList<LocalType> param,
+    Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
     ReadDest&& read_dest,
@@ -557,7 +574,7 @@ decltype(auto) CustomReadField(TypeList<LocalType> param,
 template <typename... LocalTypes, typename... Args>
 void ReadField(TypeList<LocalTypes...>, Args&&... args)
 {
-    CustomReadField(TypeList<RemoveCvRef<LocalTypes>...>(), std::forward<Args>(args)...);
+    CustomReadField(TypeList<RemoveCvRef<LocalTypes>...>(), Priority<2>(), std::forward<Args>(args)...);
 }
 
 template <typename LocalType, typename Input>
@@ -1053,6 +1070,7 @@ void CustomBuildField(TypeList<>,
 
 template <typename Input>
 decltype(auto) CustomReadField(TypeList<>,
+    Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
     typename std::enable_if<std::is_same<decltype(input.get()), ThreadMap::Client>::value>::type* enable = nullptr)

--- a/include/mp/proxy-types.h
+++ b/include/mp/proxy-types.h
@@ -977,7 +977,7 @@ auto PassField(TypeList<LocalType&>, ServerContext& server_context, Fn&& fn, Arg
     const auto& params = server_context.call_context.getParams();
     const auto& input = Make<StructField, Accessor>(params);
     using Interface = typename Decay<decltype(input.get())>::Calls;
-    auto param = std::make_unique<ProxyClient<Interface>>(input.get(), *server_context.proxy_server.m_connection);
+    auto param = std::make_unique<ProxyClient<Interface>>(input.get(), &server_context.proxy_server.m_connection, false);
     fn.invoke(server_context, std::forward<Args>(args)..., *param);
 }
 

--- a/src/mp/test/foo.capnp
+++ b/src/mp/test/foo.capnp
@@ -16,6 +16,7 @@ interface FooInterface $Proxy.wrap("mp::test::FooImplementation") {
     raise @3 (arg :FooStruct) -> (error :FooStruct $Proxy.exception("mp::test::FooStruct"));
     initThreadMap @4 (threadMap: Proxy.ThreadMap) -> (threadMap :Proxy.ThreadMap);
     callback @5 (context :Proxy.Context, callback :FooCallback, arg: Int32) -> (result :Int32);
+    callbackUnique @6 (context :Proxy.Context, callback :FooCallback, arg: Int32) -> (result :Int32);
 }
 
 interface FooCallback $Proxy.wrap("mp::test::FooCallback") {

--- a/src/mp/test/foo.capnp
+++ b/src/mp/test/foo.capnp
@@ -17,6 +17,7 @@ interface FooInterface $Proxy.wrap("mp::test::FooImplementation") {
     initThreadMap @4 (threadMap: Proxy.ThreadMap) -> (threadMap :Proxy.ThreadMap);
     callback @5 (context :Proxy.Context, callback :FooCallback, arg: Int32) -> (result :Int32);
     callbackUnique @6 (context :Proxy.Context, callback :FooCallback, arg: Int32) -> (result :Int32);
+    callbackShared @7 (context :Proxy.Context, callback :FooCallback, arg: Int32) -> (result :Int32);
 }
 
 interface FooCallback $Proxy.wrap("mp::test::FooCallback") {

--- a/src/mp/test/foo.capnp
+++ b/src/mp/test/foo.capnp
@@ -14,6 +14,13 @@ interface FooInterface $Proxy.wrap("mp::test::FooImplementation") {
     mapSize @1 (map :List(Pair(Text, Text))) -> (result :Int32);
     pass @2 (arg :FooStruct) -> (result :FooStruct);
     raise @3 (arg :FooStruct) -> (error :FooStruct $Proxy.exception("mp::test::FooStruct"));
+    initThreadMap @4 (threadMap: Proxy.ThreadMap) -> (threadMap :Proxy.ThreadMap);
+    callback @5 (context :Proxy.Context, callback :FooCallback, arg: Int32) -> (result :Int32);
+}
+
+interface FooCallback $Proxy.wrap("mp::test::FooCallback") {
+    destroy @0 (context :Proxy.Context) -> ();
+    call @1 (context :Proxy.Context, arg :Int32) -> (result :Int32);
 }
 
 struct FooStruct $Proxy.wrap("mp::test::FooStruct") {

--- a/src/mp/test/foo.capnp
+++ b/src/mp/test/foo.capnp
@@ -18,6 +18,8 @@ interface FooInterface $Proxy.wrap("mp::test::FooImplementation") {
     callback @5 (context :Proxy.Context, callback :FooCallback, arg: Int32) -> (result :Int32);
     callbackUnique @6 (context :Proxy.Context, callback :FooCallback, arg: Int32) -> (result :Int32);
     callbackShared @7 (context :Proxy.Context, callback :FooCallback, arg: Int32) -> (result :Int32);
+    saveCallback @8 (context :Proxy.Context, callback :FooCallback) -> ();
+    callbackSaved @9 (context :Proxy.Context, arg: Int32) -> (result :Int32);
 }
 
 interface FooCallback $Proxy.wrap("mp::test::FooCallback") {

--- a/src/mp/test/foo.h
+++ b/src/mp/test/foo.h
@@ -37,6 +37,9 @@ public:
     int callback(FooCallback& callback, int arg) { return callback.call(arg); }
     int callbackUnique(std::unique_ptr<FooCallback> callback, int arg) { return callback->call(arg); }
     int callbackShared(std::shared_ptr<FooCallback> callback, int arg) { return callback->call(arg); }
+    void saveCallback(std::shared_ptr<FooCallback> callback) { m_callback = std::move(callback); }
+    int callbackSaved(int arg) { return m_callback->call(arg); }
+    std::shared_ptr<FooCallback> m_callback;
 };
 
 } // namespace test

--- a/src/mp/test/foo.h
+++ b/src/mp/test/foo.h
@@ -34,7 +34,8 @@ public:
     FooStruct pass(FooStruct foo) { return foo; }
     void raise(FooStruct foo) { throw foo; }
     void initThreadMap() {}
-    int callback(std::unique_ptr<FooCallback> callback, int arg) { return callback->call(arg); }
+    int callback(FooCallback& callback, int arg) { return callback.call(arg); }
+    int callbackUnique(std::unique_ptr<FooCallback> callback, int arg) { return callback->call(arg); }
 };
 
 } // namespace test

--- a/src/mp/test/foo.h
+++ b/src/mp/test/foo.h
@@ -36,6 +36,7 @@ public:
     void initThreadMap() {}
     int callback(FooCallback& callback, int arg) { return callback.call(arg); }
     int callbackUnique(std::unique_ptr<FooCallback> callback, int arg) { return callback->call(arg); }
+    int callbackShared(std::shared_ptr<FooCallback> callback, int arg) { return callback->call(arg); }
 };
 
 } // namespace test

--- a/src/mp/test/foo.h
+++ b/src/mp/test/foo.h
@@ -19,6 +19,13 @@ struct FooStruct
     std::vector<int> num_set;
 };
 
+class FooCallback
+{
+public:
+    virtual ~FooCallback() = default;
+    virtual int call(int arg) = 0;
+};
+
 class FooImplementation
 {
 public:
@@ -26,6 +33,8 @@ public:
     int mapSize(const std::map<std::string, std::string>& map) { return map.size(); }
     FooStruct pass(FooStruct foo) { return foo; }
     void raise(FooStruct foo) { throw foo; }
+    void initThreadMap() {}
+    int callback(std::unique_ptr<FooCallback> callback, int arg) { return callback->call(arg); }
 };
 
 } // namespace test

--- a/src/mp/test/test.cpp
+++ b/src/mp/test/test.cpp
@@ -31,7 +31,7 @@ KJ_TEST("Call FooInterface methods")
         disconnect_client = [&] { loop.sync([&] { connection_client.reset(); }); };
 
         auto connection_server = std::make_unique<Connection>(loop, kj::mv(pipe.ends[1]), [&](Connection& connection) {
-            auto foo_server = kj::heap<ProxyServer<messages::FooInterface>>(new FooImplementation, true, connection);
+            auto foo_server = kj::heap<ProxyServer<messages::FooInterface>>(std::make_shared<FooImplementation>(), connection);
             return capnp::Capability::Client(kj::mv(foo_server));
         });
         connection_server->onDisconnect([&] { connection_server.reset(); });
@@ -74,7 +74,7 @@ KJ_TEST("Call FooInterface methods")
     auto saved = std::make_shared<Callback>(7, 8);
     KJ_EXPECT(saved.use_count() == 1);
     foo->saveCallback(saved);
-    // Fails: KJ_EXPECT(saved.use_count() == 2);
+    KJ_EXPECT(saved.use_count() == 2);
     foo->callbackSaved(7);
     KJ_EXPECT(foo->callbackSaved(7) == 8);
     foo->saveCallback(nullptr);

--- a/src/mp/test/test.cpp
+++ b/src/mp/test/test.cpp
@@ -70,6 +70,7 @@ KJ_TEST("Call FooInterface methods")
     Callback callback(1, 2);
     KJ_EXPECT(foo->callback(callback, 1) == 2);
     KJ_EXPECT(foo->callbackUnique(std::make_unique<Callback>(3, 4), 3) == 4);
+    KJ_EXPECT(foo->callbackShared(std::make_shared<Callback>(5, 6), 5) == 6);
 
     disconnect_client();
     thread.join();

--- a/src/mp/test/test.cpp
+++ b/src/mp/test/test.cpp
@@ -67,7 +67,9 @@ KJ_TEST("Call FooInterface methods")
     };
 
     foo->initThreadMap();
-    KJ_EXPECT(foo->callback(std::make_unique<Callback>(1, 2), 1) == 2);
+    Callback callback(1, 2);
+    KJ_EXPECT(foo->callback(callback, 1) == 2);
+    KJ_EXPECT(foo->callbackUnique(std::make_unique<Callback>(3, 4), 3) == 4);
 
     disconnect_client();
     thread.join();

--- a/src/mp/test/test.cpp
+++ b/src/mp/test/test.cpp
@@ -71,6 +71,14 @@ KJ_TEST("Call FooInterface methods")
     KJ_EXPECT(foo->callback(callback, 1) == 2);
     KJ_EXPECT(foo->callbackUnique(std::make_unique<Callback>(3, 4), 3) == 4);
     KJ_EXPECT(foo->callbackShared(std::make_shared<Callback>(5, 6), 5) == 6);
+    auto saved = std::make_shared<Callback>(7, 8);
+    KJ_EXPECT(saved.use_count() == 1);
+    foo->saveCallback(saved);
+    // Fails: KJ_EXPECT(saved.use_count() == 2);
+    foo->callbackSaved(7);
+    KJ_EXPECT(foo->callbackSaved(7) == 8);
+    foo->saveCallback(nullptr);
+    KJ_EXPECT(saved.use_count() == 1);
 
     disconnect_client();
     thread.join();


### PR DESCRIPTION
This is needed after https://github.com/bitcoin/bitcoin/pull/18338 which changed `handleNotifications()` `Notifications&` callback argument to `std::shared_ptr<Notifications>`.

Easiest way to support this was to change `ProxyServerBase` reference from a raw pointer to shared pointer and make necessary BuildField changes to pass along the `shared_ptr`. Alternative might have been to add more generic cleanup support to `ProxyServerBase` instead of hardcoding `shared_ptr`.

The change also required making the ReadField callback overload more generic, which was a straightforward but kind of big change that touched a lot of code.

There weren't any unit tests for callback support previously, so a lot of new test coverage was added. It includes coverage for `shared_ptr` lifetime correctness, making sure there's an IPC call decrementing server `shared_ptr` reference count when client `shared_ptr` proxy is reset.