### PR TITLE
Disable GCC suggest-override warnings for proxy clients

### DIFF
--- a/src/mp/gen.cpp
+++ b/src/mp/gen.cpp
@@ -201,6 +201,10 @@ void Generate(kj::StringPtr src_prefix,
     h << "#include <" << include_path << ".h>\n";
     h << "#include <" << include_base << ".h>\n";
     h << "#include <" << PROXY_DECL << ">\n\n";
+    h << "#if defined(__GNUC__) && !defined(__clang__)\n";
+    h << "#pragma GCC diagnostic push\n";
+    h << "#pragma GCC diagnostic ignored \"-Wsuggest-override\"\n";
+    h << "#endif\n";
     h << "namespace mp {\n";
 
     kj::StringPtr message_namespace;
@@ -552,6 +556,9 @@ void Generate(kj::StringPtr src_prefix,
     inl << "#endif\n";
 
     h << "} // namespace mp\n";
+    h << "#if defined(__GNUC__) && !defined(__clang__)\n";
+    h << "#pragma GCC diagnostic pop\n";
+    h << "#endif\n";
     h << "#endif\n";
 }
 


### PR DESCRIPTION
Proxy client methods are usually virtual, but in some use cases (testing, layering) they don't have to have to be and there is no reason to make generated client code try to detect or specify this. Disable the warning instead.

Warnings look like https://cirrus-ci.com/task/6000489311502336?command=ci#L4294

```
./ipc/capnp/init.capnp.proxy.h:62:25: error: ‘virtual mp::FunctionTraits<std::unique_ptr<interfaces::Echo> (interfaces::Init::* const)()>::Result mp::ProxyClient<ipc::capnp::messages::Init>::makeEcho()’ can be marked override [-Werror=suggest-override]
   62 |     typename M1::Result makeEcho();
      |                         ^~~~~~~~
cc1plus: some warnings being treated as errors
```