### PR TITLE
Support attaching custom cleanup functions to proxy client and server classes

### DIFF
--- a/include/mp/proxy-types.h
+++ b/include/mp/proxy-types.h
@@ -125,12 +125,12 @@ auto PassField(TypeList<>, ServerContext& server_context, const Fn& fn, const Ar
                 ServerContext server_context{server, call_context, req};
                 {
                     auto& request_threads = g_thread_context.request_threads;
-                    auto request_thread = request_threads.find(&server.m_connection);
+                    auto request_thread = request_threads.find(server.m_context.connection);
                     if (request_thread == request_threads.end()) {
                         request_thread =
                             g_thread_context.request_threads
-                                .emplace(std::piecewise_construct, std::forward_as_tuple(&server.m_connection),
-                                    std::forward_as_tuple(context_arg.getCallbackThread(), &server.m_connection,
+                                .emplace(std::piecewise_construct, std::forward_as_tuple(server.m_context.connection),
+                                    std::forward_as_tuple(context_arg.getCallbackThread(), server.m_context.connection,
                                         /* destroy_connection= */ false))
                                 .first;
                     } else {
@@ -142,13 +142,13 @@ auto PassField(TypeList<>, ServerContext& server_context, const Fn& fn, const Ar
                     fn.invoke(server_context, args...);
                 }
                 KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() {
-                    server.m_connection.m_loop.sync([&] {
+                    server.m_context.connection->m_loop.sync([&] {
                         auto fulfiller_dispose = kj::mv(fulfiller);
                         fulfiller_dispose->fulfill(kj::mv(call_context));
                     });
                 }))
                 {
-                    server.m_connection.m_loop.sync([&]() {
+                    server.m_context.connection->m_loop.sync([&]() {
                         auto fulfiller_dispose = kj::mv(fulfiller);
                         fulfiller_dispose->reject(kj::mv(*exception));
                     });
@@ -156,18 +156,18 @@ auto PassField(TypeList<>, ServerContext& server_context, const Fn& fn, const Ar
             })));
 
     auto thread_client = context_arg.getThread();
-    return JoinPromises(server.m_connection.m_threads.getLocalServer(thread_client)
+    return JoinPromises(server.m_context.connection->m_threads.getLocalServer(thread_client)
                             .then([&server, invoke, req](kj::Maybe<Thread::Server&> perhaps) {
                                 KJ_IF_MAYBE(thread_server, perhaps)
                                 {
                                     const auto& thread = static_cast<ProxyServer<Thread>&>(*thread_server);
-                                    server.m_connection.m_loop.log() << "IPC server post request  #" << req << " {"
+                                    server.m_context.connection->m_loop.log() << "IPC server post request  #" << req << " {"
                                                                      << thread.m_thread_context.thread_name << "}";
                                     thread.m_thread_context.waiter->post(std::move(invoke));
                                 }
                                 else
                                 {
-                                    server.m_connection.m_loop.log() << "IPC server error request #" << req
+                                    server.m_context.connection->m_loop.log() << "IPC server error request #" << req
                                                                      << ", missing thread to execute request";
                                     throw std::runtime_error("invalid thread handle");
                                 }
@@ -1014,7 +1014,7 @@ auto PassField(TypeList<LocalType&>, ServerContext& server_context, Fn&& fn, Arg
     const auto& params = server_context.call_context.getParams();
     const auto& input = Make<StructField, Accessor>(params);
     using Interface = typename Decay<decltype(input.get())>::Calls;
-    auto param = std::make_unique<ProxyClient<Interface>>(input.get(), &server_context.proxy_server.m_connection, false);
+    auto param = std::make_unique<ProxyClient<Interface>>(input.get(), server_context.proxy_server.m_context.connection, false);
     fn.invoke(server_context, std::forward<Args>(args)..., *param);
 }
 
@@ -1345,8 +1345,8 @@ struct CapRequestTraits<::capnp::Request<_Params, _Results>>
 template <typename Client>
 void clientDestroy(Client& client)
 {
-    if (client.m_connection) {
-        client.m_connection->m_loop.log() << "IPC client destroy " << typeid(client).name();
+    if (client.m_context.connection) {
+        client.m_context.connection->m_loop.log() << "IPC client destroy " << typeid(client).name();
     } else {
         KJ_LOG(INFO, "IPC interrupted client destroy", typeid(client).name());
     }
@@ -1355,18 +1355,18 @@ void clientDestroy(Client& client)
 template <typename Server>
 void serverDestroy(Server& server)
 {
-    server.m_connection.m_loop.log() << "IPC server destroy" << typeid(server).name();
+    server.m_context.connection->m_loop.log() << "IPC server destroy" << typeid(server).name();
 }
 
 template <typename ProxyClient, typename GetRequest, typename... FieldObjs>
 void clientInvoke(ProxyClient& proxy_client, const GetRequest& get_request, FieldObjs&&... fields)
 {
-    if (!proxy_client.m_connection) {
+    if (!proxy_client.m_context.connection) {
         throw std::logic_error("clientInvoke call made after disconnect");
     }
     if (!g_thread_context.waiter) {
         assert(g_thread_context.thread_name.empty());
-        g_thread_context.thread_name = ThreadName(proxy_client.m_connection->m_loop.m_exe_name);
+        g_thread_context.thread_name = ThreadName(proxy_client.m_context.connection->m_loop.m_exe_name);
         // If next assert triggers, it means clientInvoke is being called from
         // the capnp event loop thread. This can happen when a ProxyServer
         // method implementation that runs synchronously on the event loop
@@ -1377,26 +1377,26 @@ void clientInvoke(ProxyClient& proxy_client, const GetRequest& get_request, Fiel
         // declaration so the server method runs in a dedicated thread.
         assert(!g_thread_context.loop_thread);
         g_thread_context.waiter = std::make_unique<Waiter>();
-        proxy_client.m_connection->m_loop.logPlain()
+        proxy_client.m_context.connection->m_loop.logPlain()
             << "{" << g_thread_context.thread_name
             << "} IPC client first request from current thread, constructing waiter";
     }
-    ClientInvokeContext invoke_context{*proxy_client.m_connection, g_thread_context};
+    ClientInvokeContext invoke_context{*proxy_client.m_context.connection, g_thread_context};
     std::exception_ptr exception;
     std::string kj_exception;
     bool done = false;
-    proxy_client.m_connection->m_loop.sync([&]() {
+    proxy_client.m_context.connection->m_loop.sync([&]() {
         auto request = (proxy_client.m_client.*get_request)(nullptr);
         using Request = CapRequestTraits<decltype(request)>;
         using FieldList = typename ProxyClientMethodTraits<typename Request::Params>::Fields;
         IterateFields().handleChain(invoke_context, request, FieldList(), typename FieldObjs::BuildParams{&fields}...);
-        proxy_client.m_connection->m_loop.logPlain()
+        proxy_client.m_context.connection->m_loop.logPlain()
             << "{" << invoke_context.thread_context.thread_name << "} IPC client send "
             << TypeName<typename Request::Params>() << " " << LogEscape(request.toString());
 
-        proxy_client.m_connection->m_loop.m_task_set->add(request.send().then(
+        proxy_client.m_context.connection->m_loop.m_task_set->add(request.send().then(
             [&](::capnp::Response<typename Request::Results>&& response) {
-                proxy_client.m_connection->m_loop.logPlain()
+                proxy_client.m_context.connection->m_loop.logPlain()
                     << "{" << invoke_context.thread_context.thread_name << "} IPC client recv "
                     << TypeName<typename Request::Results>() << " " << LogEscape(response.toString());
                 try {
@@ -1411,7 +1411,7 @@ void clientInvoke(ProxyClient& proxy_client, const GetRequest& get_request, Fiel
             },
             [&](const ::kj::Exception& e) {
                 kj_exception = kj::str("kj::Exception: ", e).cStr();
-                proxy_client.m_connection->m_loop.logPlain()
+                proxy_client.m_context.connection->m_loop.logPlain()
                     << "{" << invoke_context.thread_context.thread_name << "} IPC client exception " << kj_exception;
                 std::unique_lock<std::mutex> lock(invoke_context.thread_context.waiter->m_mutex);
                 done = true;
@@ -1422,7 +1422,7 @@ void clientInvoke(ProxyClient& proxy_client, const GetRequest& get_request, Fiel
     std::unique_lock<std::mutex> lock(invoke_context.thread_context.waiter->m_mutex);
     invoke_context.thread_context.waiter->wait(lock, [&done]() { return done; });
     if (exception) std::rethrow_exception(exception);
-    if (!kj_exception.empty()) proxy_client.m_connection->m_loop.raise() << kj_exception;
+    if (!kj_exception.empty()) proxy_client.m_context.connection->m_loop.raise() << kj_exception;
 }
 
 //! Invoke callable `fn()` that may return void. If it does return void, replace
@@ -1454,7 +1454,7 @@ kj::Promise<void> serverInvoke(Server& server, CallContext& call_context, Fn fn)
     using Results = typename decltype(call_context.getResults())::Builds;
 
     int req = ++server_reqs;
-    server.m_connection.m_loop.log() << "IPC server recv request  #" << req << " "
+    server.m_context.connection->m_loop.log() << "IPC server recv request  #" << req << " "
                                      << TypeName<typename Params::Reads>() << " " << LogEscape(params.toString());
 
     try {
@@ -1464,14 +1464,14 @@ kj::Promise<void> serverInvoke(Server& server, CallContext& call_context, Fn fn)
         return ReplaceVoid([&]() { return fn.invoke(server_context, ArgList()); },
             [&]() { return kj::Promise<CallContext>(kj::mv(call_context)); })
             .then([&server, req](CallContext call_context) {
-                server.m_connection.m_loop.log() << "IPC server send response #" << req << " " << TypeName<Results>()
+                server.m_context.connection->m_loop.log() << "IPC server send response #" << req << " " << TypeName<Results>()
                                                  << " " << LogEscape(call_context.getResults().toString());
             });
     } catch (const std::exception& e) {
-        server.m_connection.m_loop.log() << "IPC server unhandled exception: " << e.what();
+        server.m_context.connection->m_loop.log() << "IPC server unhandled exception: " << e.what();
         throw;
     } catch (...) {
-        server.m_connection.m_loop.log() << "IPC server unhandled exception";
+        server.m_context.connection->m_loop.log() << "IPC server unhandled exception";
         throw;
     }
 }

--- a/include/mp/proxy.h
+++ b/include/mp/proxy.h
@@ -39,6 +39,14 @@ struct ProxyType;
 using CleanupList = std::list<std::function<void()>>;
 using CleanupIt = typename CleanupList::iterator;
 
+//! Context data associated with proxy client and server classes.
+struct ProxyContext
+{
+    Connection* connection;
+
+    ProxyContext(Connection* connection) : connection(connection) {}
+};
+
 //! Base class for generated ProxyClient classes that implement a C++ interface
 //! and forward calls to a capnp interface.
 template <typename Interface_, typename Impl_>
@@ -59,7 +67,7 @@ public:
     ProxyClient<Interface>& self() { return static_cast<ProxyClient<Interface>&>(*this); }
 
     typename Interface::Client m_client;
-    Connection* m_connection;
+    ProxyContext m_context;
     bool m_destroy_connection;
     CleanupIt m_cleanup; //!< Pointer to self-cleanup callback registered to handle connection object getting destroyed
                          //!< before this client object.
@@ -100,7 +108,7 @@ public:
      * appropriate times depending on semantics of the particular method being
      * wrapped. */
     std::shared_ptr<Impl> m_impl;
-    Connection& m_connection;
+    ProxyContext m_context;
 };
 
 //! Customizable (through template specialization) base class used in generated ProxyServer implementations from

--- a/include/mp/proxy.h
+++ b/include/mp/proxy.h
@@ -43,6 +43,7 @@ using CleanupIt = typename CleanupList::iterator;
 struct ProxyContext
 {
     Connection* connection;
+    std::list<std::function<void()>> cleanup;
 
     ProxyContext(Connection* connection) : connection(connection) {}
 };
@@ -68,9 +69,6 @@ public:
 
     typename Interface::Client m_client;
     ProxyContext m_context;
-    bool m_destroy_connection;
-    CleanupIt m_cleanup; //!< Pointer to self-cleanup callback registered to handle connection object getting destroyed
-                         //!< before this client object.
 };
 
 //! Customizable (through template specialization) base class used in generated ProxyClient implementations from

--- a/src/mp/gen.cpp
+++ b/src/mp/gen.cpp
@@ -532,6 +532,18 @@ void Generate(kj::StringPtr src_prefix,
             client << "};\n";
             server << "};\n";
             dec << "\n" << client.str() << "\n" << server.str() << "\n";
+            KJ_IF_MAYBE(bracket, proxied_class_type.findFirst('<')) {
+              // Skip ProxyType definition for complex type expressions which
+              // could lead to duplicate definitions. They can be defined
+              // manually if actually needed.
+            } else {
+              dec << "template<>\nstruct ProxyType<" << proxied_class_type << ">\n{\n";
+              dec << "    using Type = " << proxied_class_type << ";\n";
+              dec << "    using Message = " << message_namespace << "::" << node_name << ";\n";
+              dec << "    using Client = ProxyClient<Message>;\n";
+              dec << "    using Server = ProxyServer<Message>;\n";
+              dec << "};\n";
+            }
             def_types << "ProxyClient<" << message_namespace << "::" << node_name
                       << ">::~ProxyClient() { clientDestroy(*this); " << client_destroy.str() << " }\n";
             def_types << "ProxyServer<" << message_namespace << "::" << node_name

--- a/src/mp/gen.cpp
+++ b/src/mp/gen.cpp
@@ -222,6 +222,7 @@ void Generate(kj::StringPtr src_prefix,
     std::ostringstream dec;
     std::ostringstream def_server;
     std::ostringstream def_client;
+    std::ostringstream int_client;
     std::ostringstream def_types;
 
     auto add_accessor = [&](kj::StringPtr name) {
@@ -543,6 +544,7 @@ void Generate(kj::StringPtr src_prefix,
               dec << "    using Client = ProxyClient<Message>;\n";
               dec << "    using Server = ProxyServer<Message>;\n";
               dec << "};\n";
+              int_client << "ProxyTypeRegister t" << node_nested.getId() << "{TypeList<" << proxied_class_type << ">{}};\n";
             }
             def_types << "ProxyClient<" << message_namespace << "::" << node_name
                       << ">::~ProxyClient() { clientDestroy(*this); " << client_destroy.str() << " }\n";
@@ -559,6 +561,7 @@ void Generate(kj::StringPtr src_prefix,
     cpp_server << "} // namespace mp\n";
 
     cpp_client << def_client.str();
+    cpp_client << "namespace {\n" << int_client.str() << "} // namespace\n";
     cpp_client << "} // namespace mp\n";
 
     cpp_types << def_types.str();

--- a/test/src/mp/test/test.cpp
+++ b/test/src/mp/test/test.cpp
@@ -88,6 +88,11 @@ KJ_TEST("Call FooInterface methods")
 
     disconnect_client();
     thread.join();
+
+    bool destroyed = false;
+    foo->m_context.cleanup.emplace_front([&destroyed]{ destroyed = true; });
+    foo.reset();
+    KJ_EXPECT(destroyed);
 }
 
 } // namespace test


### PR DESCRIPTION
This avoids the need to add interface base classes with `addCloseHook` methods in https://github.com/bitcoin/bitcoin/pull/19160 and https://github.com/bitcoin/bitcoin/pull/10102