### PR TITLE
gen.cpp: Check local includes before install includes

### DIFF
--- a/src/mp/gen.cpp
+++ b/src/mp/gen.cpp
@@ -598,15 +598,15 @@ int main(int argc, char** argv)
     auto fs = kj::newDiskFilesystem();
     auto cwd = fs->getCurrentPath();
 #endif
+    for (size_t i = 4; i < argc; ++i) {
+        import_paths.push_back(argv[i]);
+    }
     for (const char* path : {CMAKE_INSTALL_PREFIX "/include", capnp_PREFIX "/include"}) {
 #ifdef HAVE_KJ_FILESYSTEM
         KJ_IF_MAYBE(dir, fs->getRoot().tryOpenSubdir(cwd.evalNative(path))) { import_paths.emplace_back(path); }
 #else
         import_paths.emplace_back(path);
 #endif
-    }
-    for (size_t i = 4; i < argc; ++i) {
-        import_paths.push_back(argv[i]);
     }
     Generate(argv[1], argv[2], argv[3], {import_paths.data(), import_paths.size()});
     return 0;


### PR DESCRIPTION
Fix `make check` if previous incompatible version of libmultiprocess is installed and `make install` hasn't been run yet to update it.

Carl Dong reported this issue in https://github.com/chaincodelabs/libmultiprocess/issues/44 and confirmed the fix in https://github.com/chaincodelabs/libmultiprocess/issues/44#issuecomment-781658244