### PR TITLE
Fix std::move compiler warning

### DIFF
--- a/include/mp/proxy-io.h
+++ b/include/mp/proxy-io.h
@@ -157,7 +157,7 @@ public:
     {
         Logger logger(false, m_log_fn);
         logger << "{" << LongThreadName(m_exe_name) << "} ";
-        return std::move(logger);
+        return logger;
     }
     Logger logPlain() { return Logger(false, m_log_fn); }
     Logger raise() { return Logger(true, m_log_fn); }


### PR DESCRIPTION
```
include/mp/proxy-io.h: In member function ‘mp::Logger mp::EventLoop::log()’:
include/mp/proxy-io.h:160:25: error: moving a local object in a return statement prevents copy elision [-Werror=pessimizing-move]
  160 |         return std::move(logger);
      |                ~~~~~~~~~^~~~~~~~
include/mp/proxy-io.h:160:25: note: remove ‘std::move’ call
```