### PR TITLE
Fix mptest link error caused by missing kj-async dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,10 @@ target_include_directories(multiprocess PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
   $<INSTALL_INTERFACE:include>
   ${CAPNP_INCLUDE_DIRECTORY})
+target_link_libraries(multiprocess PRIVATE CapnProto::capnp)
+target_link_libraries(multiprocess PRIVATE CapnProto::capnp-rpc)
+target_link_libraries(multiprocess PRIVATE CapnProto::kj)
+target_link_libraries(multiprocess PRIVATE CapnProto::kj-async)
 set_target_properties(multiprocess PROPERTIES
     PUBLIC_HEADER "${MP_PUBLIC_HEADERS}"
     CXX_STANDARD 17


### PR DESCRIPTION
Error looks like:

```
ld: ../libmultiprocess.a(proxy.cpp.o): in function `mp::EventLoop::EventLoop(char const*, std::function<void (bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)>, void*)':
libmultiprocess/src/mp/proxy.cpp:130: undefined reference to `kj::setupAsyncIo()'
collect2: error: ld returned 1 exit status
```