### PR TITLE
cleanup: Remove AUTORET macro and clean up PassField overrides

### DIFF
--- a/include/mp/proxy-types.h
+++ b/include/mp/proxy-types.h
@@ -45,7 +45,7 @@ struct StructField
     template<typename A = Accessor> auto want() const -> typename std::enable_if<A::requested, bool>::type { return A::getWant(m_struct); }
     template<typename A = Accessor> auto want() const -> typename std::enable_if<!A::requested, bool>::type { return true; }
     template<typename A = Accessor, typename... Args> decltype(auto) set(Args&&... args) const { return A::set(this->m_struct, std::forward<Args>(args)...); }
-    template<typename A = Accessor, typename... Args> auto init(Args&&... args) const -> AUTO_RETURN(A::init(this->m_struct, std::forward<Args>(args)...))
+    template<typename A = Accessor, typename... Args> decltype(auto) init(Args&&... args) const { return A::init(this->m_struct, std::forward<Args>(args)...); }
     template<typename A = Accessor> auto setHas() const -> typename std::enable_if<A::optional>::type { return A::setHas(m_struct); }
     template<typename A = Accessor> auto setHas() const -> typename std::enable_if<!A::optional>::type { }
     template<typename A = Accessor> auto setWant() const -> typename std::enable_if<A::requested>::type { return A::setWant(m_struct); }
@@ -58,7 +58,7 @@ void CustomBuildField(TypeList<>,
     Priority<1>,
     ClientInvokeContext& invoke_context,
     Output&& output,
-    typename std::enable_if<std::is_same<decltype(output.init()), Context::Builder>::value>::type* enable = nullptr)
+    typename std::enable_if<std::is_same<decltype(output.get()), Context::Builder>::value>::type* enable = nullptr)
 {
     auto& connection = invoke_context.connection;
     auto& thread_context = invoke_context.thread_context;

--- a/include/mp/proxy-types.h
+++ b/include/mp/proxy-types.h
@@ -38,7 +38,7 @@ struct StructField
     Struct& m_struct;
 
     // clang-format off
-    template<typename A = Accessor> auto get() const -> AUTO_RETURN(A::get(this->m_struct))
+    template<typename A = Accessor> auto get() const -> decltype(A::get(this->m_struct)) { return A::get(this->m_struct); }
     template<typename A = Accessor> auto has() const -> typename std::enable_if<A::optional, bool>::type { return A::getHas(m_struct); }
     template<typename A = Accessor> auto has() const -> typename std::enable_if<!A::optional && A::boxed, bool>::type { return A::has(m_struct); }
     template<typename A = Accessor> auto has() const -> typename std::enable_if<!A::optional && !A::boxed, bool>::type { return true; }

--- a/include/mp/proxy.h
+++ b/include/mp/proxy.h
@@ -163,8 +163,10 @@ struct ProxyMethodTraits<MethodParams, Require<decltype(ProxyMethod<MethodParams
     : public FunctionTraits<decltype(ProxyMethod<MethodParams>::impl)>
 {
     template <typename ServerContext, typename... Args>
-    static auto invoke(ServerContext& server_context, Args&&... args) -> AUTO_RETURN(
-        (server_context.proxy_server.m_impl.get()->*ProxyMethod<MethodParams>::impl)(std::forward<Args>(args)...))
+    static decltype(auto) invoke(ServerContext& server_context, Args&&... args)
+    {
+        return (server_context.proxy_server.m_impl.get()->*ProxyMethod<MethodParams>::impl)(std::forward<Args>(args)...);
+    }
 };
 
 //! Customizable (through template specialization) traits class used in generated ProxyClient implementations from

--- a/include/mp/util.h
+++ b/include/mp/util.h
@@ -55,17 +55,6 @@ namespace mp {
 //!        }
 //!     };
 
-// C++11 workaround for C++14 auto return functions
-// (http://en.cppreference.com/w/cpp/language/template_argument_deduction#auto-returning_functions)
-#define AUTO_DO_RETURN(pre, x) \
-    decltype(x)                \
-    {                          \
-        pre;                   \
-        return x;              \
-    }
-
-#define AUTO_RETURN(x) AUTO_DO_RETURN(, x)
-
 //! Type holding a list of types.
 //!
 //! Example:

--- a/include/mp/util.h
+++ b/include/mp/util.h
@@ -102,7 +102,7 @@ struct ComposeFn
     Fn2&& fn2;
 
     template <typename... Args>
-    auto operator()(Args&&... args) -> AUTO_RETURN(this->fn1(this->fn2(std::forward<Args>(args)...)))
+    decltype(auto) operator()(Args&&... args) { return this->fn1(this->fn2(std::forward<Args>(args)...)); }
 };
 
 //! Bound function. See Bind() below.
@@ -116,8 +116,10 @@ struct BoundFn<Fn, TypeList<>, TypeList<BoundArgs...>>
     Fn&& m_fn;
 
     template <typename... FreeArgs>
-    auto operator()(BoundArgs&... bound_args, FreeArgs&&... free_args)
-        -> AUTO_RETURN(this->m_fn(bound_args..., std::forward<FreeArgs>(free_args)...))
+    decltype(auto) operator()(BoundArgs&... bound_args, FreeArgs&&... free_args)
+    {
+        return this->m_fn(bound_args..., std::forward<FreeArgs>(free_args)...);
+    }
 };
 
 //! Specialization of above for recursive case.
@@ -130,7 +132,7 @@ struct BoundFn<Fn, TypeList<BindArg, BindArgs...>, TypeList<BoundArgs...>>
 
     BoundFn(Fn& fn, BindArg& bind_arg, BindArgs&... bind_args) : Base{fn, bind_args...}, m_bind_arg(bind_arg) {}
 
-    // Use std::result_of instead of AUTO_RETURN to work around gcc bug
+    // Use std::result_of instead of decltype return to work around gcc bug
     // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83249
     template <typename... FreeArgs>
     auto operator()(BoundArgs&... bound_args, FreeArgs&&... free_args) ->
@@ -167,7 +169,7 @@ struct BoundTupleFn
 {
     Fn& m_fn;
     template <typename... Params>
-    auto operator()(Params&&... params) -> AUTO_RETURN(this->m_fn(std::forward_as_tuple(params...)))
+    decltype(auto) operator()(Params&&... params) { return this->m_fn(std::forward_as_tuple(params...)); }
 };
 
 //! Bind tuple argument to function. Arguments passed to the returned function

--- a/src/mp/gen.cpp
+++ b/src/mp/gen.cpp
@@ -244,8 +244,8 @@ void Generate(kj::StringPtr src_prefix,
         accessors << "    template<typename S> static bool has(S&& s) { return s.has" << cap << "(); }\n";
         accessors << "    template<typename S, typename A> static void set(S&& s, A&& a) { s.set" << cap
                   << "(std::forward<A>(a)); }\n";
-        accessors << "    template<typename S, typename... A> static auto init(S&& s, A&&... a) -> AUTO_RETURN(s.init"
-                  << cap << "(std::forward<A>(a)...))\n";
+        accessors << "    template<typename S, typename... A> static decltype(auto) init(S&& s, A&&... a) { return s.init"
+                  << cap << "(std::forward<A>(a)...); }\n";
         accessors << "    template<typename S> static bool getWant(S&& s) { return s.getWant" << cap << "(); }\n";
         accessors << "    template<typename S> static void setWant(S&& s) { s.setWant" << cap << "(true); }\n";
         accessors << "    template<typename S> static bool getHas(S&& s) { return s.getHas" << cap << "(); }\n";

--- a/src/mp/gen.cpp
+++ b/src/mp/gen.cpp
@@ -317,8 +317,8 @@ void Generate(kj::StringPtr src_prefix,
                     auto field_name = field.getProto().getName();
                     auto member_name = field_name;
                     GetAnnotationText(field.getProto(), NAME_ANNOTATION_ID, &member_name);
-                    inl << "    static auto get(std::integral_constant<size_t, " << i << ">) -> AUTO_RETURN("
-                        << "&" << proxied_class_type << "::" << member_name << ")\n";
+                    inl << "    static decltype(auto) get(std::integral_constant<size_t, " << i << ">) { return "
+                        << "&" << proxied_class_type << "::" << member_name << "; }\n";
                     ++i;
                 }
                 inl << "    static constexpr size_t fields = " << i << ";\n";

--- a/src/mp/gen.cpp
+++ b/src/mp/gen.cpp
@@ -240,7 +240,7 @@ void Generate(kj::StringPtr src_prefix,
         std::string cap = Cap(name);
         accessors << "struct " << cap << "\n";
         accessors << "{\n";
-        accessors << "    template<typename S> static auto get(S&& s) -> AUTO_RETURN(s.get" << cap << "())\n";
+        accessors << "    template<typename S> static auto get(S&& s) -> decltype(s.get" << cap << "()) { return s.get" << cap << "(); }\n";
         accessors << "    template<typename S> static bool has(S&& s) { return s.has" << cap << "(); }\n";
         accessors << "    template<typename S, typename A> static void set(S&& s, A&& a) { s.set" << cap
                   << "(std::forward<A>(a)); }\n";


### PR DESCRIPTION
This is part of #46. `AUTORET` macro is no longer needed with C++14 `decltype(auto)`