### PR TITLE
Fix clang "unknown warning group" errors

### DIFF
--- a/src/mp/gen.cpp
+++ b/src/mp/gen.cpp
@@ -213,7 +213,11 @@ void Generate(kj::StringPtr src_prefix,
     h << "#include <" << PROXY_DECL << ">\n\n";
     h << "#if defined(__GNUC__)\n";
     h << "#pragma GCC diagnostic push\n";
+    h << "#if !defined(__has_warning)\n";
     h << "#pragma GCC diagnostic ignored \"-Wsuggest-override\"\n";
+    h << "#elif __has_warning(\"-Wsuggest-override\")\n";
+    h << "#pragma GCC diagnostic ignored \"-Wsuggest-override\"\n";
+    h << "#endif\n";
     h << "#endif\n";
     h << "namespace mp {\n";
 


### PR DESCRIPTION
Use clang __has_warning macro to avoid `unknown warning group '-Wsuggest-override'` warning in older versions of clang that have the `__has_warning` macro but don't have the `suggest-override` warning.

Errors were showing up https://github.com/bitcoin/bitcoin/pull/10102/checks?check_run_id=4671391974 / https://cirrus-ci.com/task/4642955743985664