### PR TITLE
Fix CMake minimum required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.8)
 project("Libmultiprocess" CXX)
 include(CMakePushCheckState)
 include(CheckCXXSourceCompiles)


### PR DESCRIPTION
The "C++17" value of the [`CXX_STANDARD`](https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html) target property, which was introduced in chaincodelabs/libmultiprocess#25, is available in CMake 3.8 and newer.

Tested with old CMake versions available [here](https://cmake.org/files/).