### PR TITLE
Fix check for `pthread_threadid_np`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ check_cxx_source_compiles("
   HAVE_PTHREAD_GETNAME_NP)
 
 check_cxx_source_compiles("
+  #include <cstdint>
   #include <pthread.h>
   int main(int argc, char** argv)
   {


### PR DESCRIPTION
Otherwise, the test always fails with "error: ‘uint64_t’ was not declared in this scope".