### PR TITLE
Use defined `CXX_STANDARD` for environment introspection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,11 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 cmake_minimum_required(VERSION 3.8)
+
 project("Libmultiprocess" CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+
 include(CMakePushCheckState)
 include(CheckCXXSourceCompiles)
 find_package(CapnProto REQUIRED)
@@ -68,9 +72,7 @@ target_link_libraries(multiprocess PRIVATE CapnProto::capnp-rpc)
 target_link_libraries(multiprocess PRIVATE CapnProto::kj)
 target_link_libraries(multiprocess PRIVATE CapnProto::kj-async)
 set_target_properties(multiprocess PROPERTIES
-    PUBLIC_HEADER "${MP_PUBLIC_HEADERS}"
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED YES)
+    PUBLIC_HEADER "${MP_PUBLIC_HEADERS}")
 install(TARGETS multiprocess EXPORT Multiprocess ARCHIVE DESTINATION lib PUBLIC_HEADER DESTINATION include/mp)
 
 add_executable(mpgen src/mp/gen.cpp)
@@ -83,9 +85,7 @@ target_link_libraries(mpgen PRIVATE CapnProto::kj)
 target_link_libraries(mpgen PRIVATE Threads::Threads)
 target_link_libraries(mpgen PRIVATE multiprocess)
 set_target_properties(mpgen PROPERTIES
-    INSTALL_RPATH_USE_LINK_PATH TRUE
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED YES)
+    INSTALL_RPATH_USE_LINK_PATH TRUE)
 install(TARGETS mpgen EXPORT Multiprocess RUNTIME DESTINATION bin)
 
 configure_file(include/mp/config.h.in "${CMAKE_CURRENT_BINARY_DIR}/include/mp/config.h")

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -63,9 +63,6 @@ target_link_libraries(mpcalculator PRIVATE CapnProto::kj)
 target_link_libraries(mpcalculator PRIVATE CapnProto::kj-async)
 target_link_libraries(mpcalculator PRIVATE Threads::Threads)
 target_link_libraries(mpcalculator PRIVATE multiprocess)
-set_target_properties(mpcalculator PROPERTIES
-  CXX_STANDARD 17
-  CXX_STANDARD_REQUIRED YES)
 
 add_custom_command(
   OUTPUT
@@ -115,9 +112,6 @@ target_link_libraries(mpprinter PRIVATE CapnProto::kj)
 target_link_libraries(mpprinter PRIVATE CapnProto::kj-async)
 target_link_libraries(mpprinter PRIVATE Threads::Threads)
 target_link_libraries(mpprinter PRIVATE multiprocess)
-set_target_properties(mpprinter PROPERTIES
-  CXX_STANDARD 17
-  CXX_STANDARD_REQUIRED YES)
 
 add_executable(mpexample
   calculator.capnp.c++
@@ -157,8 +151,5 @@ target_link_libraries(mpexample PRIVATE CapnProto::kj-async)
 target_link_libraries(mpexample PRIVATE Threads::Threads)
 target_link_libraries(mpexample PRIVATE multiprocess)
 target_link_libraries(mpexample PRIVATE stdc++fs)
-set_target_properties(mpexample PROPERTIES
-  CXX_STANDARD 17
-  CXX_STANDARD_REQUIRED YES)
 
 add_custom_target(example DEPENDS mpexample mpcalculator mpprinter)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,9 +55,6 @@ if(BUILD_TESTING AND TARGET CapnProto::kj-test)
   target_link_libraries(mptest PRIVATE CapnProto::kj-test)
   target_link_libraries(mptest PRIVATE Threads::Threads)
   target_link_libraries(mptest PRIVATE multiprocess)
-  set_target_properties(mptest PROPERTIES
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED YES)
 
   add_dependencies(tests mptest)
   add_test(NAME mptest COMMAND mptest)


### PR DESCRIPTION
It doesn't look robust to use different C++ standards for configuration and building.

This PR, for example, will apply the `-std=gnu++17` compiler option for all checks during configuration when building with GCC.