### PR TITLE
Make `mpgen` target independent from `multiprocess` one

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,11 @@ cmake_pop_check_state()
 
 capnp_generate_cpp(MP_PROXY_SRCS MP_PROXY_HDRS include/mp/proxy.capnp)
 
+add_library(util OBJECT src/mp/util.cpp)
+target_include_directories(util PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
+
 set(MP_PUBLIC_HEADERS
   ${MP_PROXY_HDRS}
   include/mp/proxy-io.h
@@ -56,7 +61,7 @@ add_library(multiprocess STATIC
   ${MP_PROXY_SRCS}
   ${MP_PUBLIC_HEADERS}
   src/mp/proxy.cpp
-  src/mp/util.cpp)
+  $<TARGET_OBJECTS:util>)
 target_include_directories(multiprocess PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -73,7 +78,7 @@ set_target_properties(multiprocess PROPERTIES
     CXX_STANDARD_REQUIRED YES)
 install(TARGETS multiprocess EXPORT Multiprocess ARCHIVE DESTINATION lib PUBLIC_HEADER DESTINATION include/mp)
 
-add_executable(mpgen src/mp/gen.cpp)
+add_executable(mpgen src/mp/gen.cpp $<TARGET_OBJECTS:util>)
 target_include_directories(mpgen PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
 target_include_directories(mpgen PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
 target_link_libraries(mpgen PRIVATE CapnProto::capnp)
@@ -81,7 +86,6 @@ target_link_libraries(mpgen PRIVATE CapnProto::capnp-rpc)
 target_link_libraries(mpgen PRIVATE CapnProto::capnpc)
 target_link_libraries(mpgen PRIVATE CapnProto::kj)
 target_link_libraries(mpgen PRIVATE Threads::Threads)
-target_link_libraries(mpgen PRIVATE multiprocess)
 set_target_properties(mpgen PROPERTIES
     INSTALL_RPATH_USE_LINK_PATH TRUE
     CXX_STANDARD 17


### PR DESCRIPTION
Instead of dependency `mpgen` on `multiprocess`, both of them can share the `util` object library.

This is a step towards ability to build and install `mpgen` and `multiprocess` independently, especially when [cross](https://github.com/bitcoin/bitcoin/pull/25941) building.