### PR TITLE
Drop unneeded include directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,6 @@ add_library(multiprocess STATIC
 target_include_directories(multiprocess PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
   $<INSTALL_INTERFACE:include>
   ${CAPNP_INCLUDE_DIRECTORY})
 target_link_libraries(multiprocess PRIVATE CapnProto::capnp)


### PR DESCRIPTION
No headers reside in the `${CMAKE_CURRENT_SOURCE_DIR}/src>` directory.

No changes in behavior.