### PR TITLE
Install Exports for custom `install-{lib,bin}` targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 include(CMakePushCheckState)
 include(CheckCXXSourceCompiles)
+include(GNUInstallDirs)
 find_package(CapnProto REQUIRED)
 find_package(Threads REQUIRED)
 
@@ -70,7 +71,7 @@ add_library(multiprocess STATIC
 target_include_directories(multiprocess PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   ${CAPNP_INCLUDE_DIRECTORY})
 target_link_libraries(multiprocess PRIVATE CapnProto::capnp)
 target_link_libraries(multiprocess PRIVATE CapnProto::capnp-rpc)
@@ -79,10 +80,10 @@ target_link_libraries(multiprocess PRIVATE CapnProto::kj-async)
 set_target_properties(multiprocess PROPERTIES
     PUBLIC_HEADER "${MP_PUBLIC_HEADERS}")
 install(TARGETS multiprocess EXPORT Multiprocess
-  ARCHIVE DESTINATION lib COMPONENT lib
-  PUBLIC_HEADER DESTINATION include/mp COMPONENT lib)
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT lib
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mp COMPONENT lib)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/libmultiprocess.pc"
-  DESTINATION "lib/pkgconfig" COMPONENT lib)
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT lib)
 add_custom_target(install-lib
   COMMAND ${CMAKE_COMMAND} -DCOMPONENT=lib -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_install.cmake
   VERBATIM)
@@ -90,7 +91,7 @@ add_dependencies(install-lib multiprocess)
 
 add_executable(mpgen src/mp/gen.cpp $<TARGET_OBJECTS:util>)
 target_include_directories(mpgen PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
-target_include_directories(mpgen PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
+target_include_directories(mpgen PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_link_libraries(mpgen PRIVATE CapnProto::capnp)
 target_link_libraries(mpgen PRIVATE CapnProto::capnp-rpc)
 target_link_libraries(mpgen PRIVATE CapnProto::capnpc)
@@ -101,10 +102,10 @@ set_target_properties(mpgen PROPERTIES
 set_target_properties(mpgen PROPERTIES
     PUBLIC_HEADER include/mp/proxy.capnp)
 install(TARGETS mpgen EXPORT Multiprocess
-  RUNTIME DESTINATION bin COMPONENT bin
-  PUBLIC_HEADER DESTINATION include/mp COMPONENT bin)
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT bin
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mp COMPONENT bin)
 install(FILES "include/mpgen.mk"
-  DESTINATION "include" COMPONENT bin)
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT bin)
 add_custom_target(install-bin
   COMMAND ${CMAKE_COMMAND} -DCOMPONENT=bin -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_install.cmake
   VERBATIM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,11 +79,14 @@ target_link_libraries(multiprocess PRIVATE CapnProto::kj)
 target_link_libraries(multiprocess PRIVATE CapnProto::kj-async)
 set_target_properties(multiprocess PROPERTIES
     PUBLIC_HEADER "${MP_PUBLIC_HEADERS}")
-install(TARGETS multiprocess EXPORT Multiprocess
+install(TARGETS multiprocess EXPORT libmultiprocess-lib
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT lib
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mp COMPONENT lib)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/libmultiprocess.pc"
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT lib)
+install(EXPORT libmultiprocess-lib
+  NAMESPACE Libmultiprocess::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake COMPONENT lib)
 add_custom_target(install-lib
   COMMAND ${CMAKE_COMMAND} -DCOMPONENT=lib -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_install.cmake
   VERBATIM)
@@ -101,11 +104,14 @@ set_target_properties(mpgen PROPERTIES
     INSTALL_RPATH_USE_LINK_PATH TRUE)
 set_target_properties(mpgen PROPERTIES
     PUBLIC_HEADER include/mp/proxy.capnp)
-install(TARGETS mpgen EXPORT Multiprocess
+install(TARGETS mpgen EXPORT libmultiprocess-bin
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT bin
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mp COMPONENT bin)
 install(FILES "include/mpgen.mk"
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT bin)
+install(EXPORT libmultiprocess-bin
+  NAMESPACE Libmultiprocess::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake COMPONENT bin)
 add_custom_target(install-bin
   COMMAND ${CMAKE_COMMAND} -DCOMPONENT=bin -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_install.cmake
   VERBATIM)
@@ -113,8 +119,6 @@ add_dependencies(install-bin mpgen)
 
 configure_file(include/mp/config.h.in "${CMAKE_CURRENT_BINARY_DIR}/include/mp/config.h")
 configure_file(pkgconfig/libmultiprocess.pc.in "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/libmultiprocess.pc" @ONLY)
-
-install(EXPORT Multiprocess DESTINATION lib/cmake/Multiprocess)
 
 add_subdirectory(example EXCLUDE_FROM_ALL)
 add_subdirectory(test EXCLUDE_FROM_ALL)


### PR DESCRIPTION
This is a follow up of chaincodelabs/libmultiprocess#74 and addresses https://github.com/chaincodelabs/libmultiprocess/pull/74#pullrequestreview-1106150689:
> > The only downside of the current implementation is that new `install-lib` and `install-bin` targets do not export the underlying targets.
> 
> Can confirm neither of the new install commands create `$PREFIX/cmake/Multiprocess/Multiprocess.cmake` and `$PREFIX/lib/cmake/Multiprocess/Multiprocess-debug.cmake` files.
> 
> Probably should update `install()` `EXPORT Multiprocess` arguments to `EXPORT libmultiprocess-bin` and `EXPORT libmultiprocess-lib` so the two installs can be independent. And maybe there is a way to get the new `install-bin` and `install-lib` commands to actually export these targets.

