### PR TITLE
Add ReadDestTemp function to make it easier to call ReadField with less boilerplate

### DIFF
--- a/test/mp/test/foo-types.h
+++ b/test/mp/test/foo-types.h
@@ -5,8 +5,27 @@
 #ifndef MP_TEST_FOO_TYPES_H
 #define MP_TEST_FOO_TYPES_H
 
+#include <mp/proxy-types.h>
+
 namespace mp {
 namespace test {
+
+template <typename Output>
+void CustomBuildField(TypeList<FooCustom>, Priority<1>, InvokeContext& invoke_context, const FooCustom& value, Output&& output)
+{
+    BuildField(TypeList<std::string>(), invoke_context, output, value.v1);
+    output.setV2(value.v2);
+}
+
+template <typename Input, typename ReadDest>
+decltype(auto) CustomReadField(TypeList<FooCustom>, Priority<1>, InvokeContext& invoke_context, Input&& input, ReadDest&& read_dest)
+{
+    messages::FooCustom::Reader custom = input.get();
+    return read_dest.update([&](FooCustom& value) {
+        value.v1 = ReadField(TypeList<std::string>(), invoke_context, mp::Make<mp::ValueField>(custom.getV1()), ReadDestTemp<std::string>());
+        value.v2 = custom.getV2();
+    });
+}
 
 } // namespace test
 } // namespace mp

--- a/test/mp/test/foo.capnp
+++ b/test/mp/test/foo.capnp
@@ -23,6 +23,7 @@ interface FooInterface $Proxy.wrap("mp::test::FooImplementation") {
     saveCallback @8 (context :Proxy.Context, callback :FooCallback) -> ();
     callbackSaved @9 (context :Proxy.Context, arg: Int32) -> (result :Int32);
     callbackExtended @10 (context :Proxy.Context, callback :ExtendedCallback, arg: Int32) -> (result :Int32);
+    passCustom @11 (arg :FooCustom) -> (result :FooCustom);
 }
 
 interface FooCallback $Proxy.wrap("mp::test::FooCallback") {
@@ -36,6 +37,11 @@ interface ExtendedCallback extends(FooCallback) $Proxy.wrap("mp::test::ExtendedC
 
 struct FooStruct $Proxy.wrap("mp::test::FooStruct") {
     name @0 :Text;
+}
+
+struct FooCustom $Proxy.wrap("mp::test::FooCustom") {
+    v1 @0 :Text;
+    v2 @1 :Int32;
 }
 
 struct Pair(Key, Value) {

--- a/test/mp/test/foo.h
+++ b/test/mp/test/foo.h
@@ -19,6 +19,12 @@ struct FooStruct
     std::vector<int> num_set;
 };
 
+struct FooCustom
+{
+    std::string v1;
+    int v2;
+};
+
 class FooCallback
 {
 public:
@@ -46,6 +52,7 @@ public:
     void saveCallback(std::shared_ptr<FooCallback> callback) { m_callback = std::move(callback); }
     int callbackSaved(int arg) { return m_callback->call(arg); }
     int callbackExtended(ExtendedCallback& callback, int arg) { return callback.callExtended(arg); }
+    FooCustom passCustom(FooCustom foo) { return foo; }
     std::shared_ptr<FooCallback> m_callback;
 };
 

--- a/test/mp/test/test.cpp
+++ b/test/mp/test/test.cpp
@@ -86,6 +86,13 @@ KJ_TEST("Call FooInterface methods")
     KJ_EXPECT(saved.use_count() == 1);
     KJ_EXPECT(foo->callbackExtended(callback, 11) == 12);
 
+    FooCustom custom_in;
+    custom_in.v1 = "v1";
+    custom_in.v2 = 5;
+    FooCustom custom_out = foo->passCustom(custom_in);
+    KJ_EXPECT(custom_in.v1 == custom_out.v1);
+    KJ_EXPECT(custom_in.v2 == custom_out.v2);
+
     disconnect_client();
     thread.join();
 


### PR DESCRIPTION
Add `RestDestTemp` function to simplify `ReadField` calls that just want to read a field into a new object.

Instead of requiring `ReadField` callers to construct the object in advance and pass it with `ReadDestValue`, or to write a custom emplace function and pass it with `ReadDestEmplace`, they can use `RestDestTemp` to make `ReadField` just construct a temporary object internally that can be moved from.

Add test coverage for this. Also add missing documentation comments for `ReadDestEmplace` and `ReadDestValue` classes.