### PR TITLE
build: Fix missing Cap'n Proto include directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,8 @@ capnp_generate_cpp(MP_PROXY_SRCS MP_PROXY_HDRS include/mp/proxy.capnp)
 add_library(util OBJECT src/mp/util.cpp)
 target_include_directories(util PRIVATE
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
-  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
+  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+  ${CAPNP_INCLUDE_DIRECTORY})
 
 set(MP_PUBLIC_HEADERS
   ${MP_PROXY_HDRS}

--- a/cmake/capnp_compat.cmake
+++ b/cmake/capnp_compat.cmake
@@ -55,6 +55,6 @@ if (NOT TARGET CapnProto::kj-async AND DEFINED CAPNP_LIB_KJ-ASYNC)
 endif()
 
 cmake_push_check_state()
-set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${capnp_INCLUDE_DIRS})
+set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${CAPNP_INCLUDE_DIRS})
 check_include_file_cxx("kj/filesystem.h" HAVE_KJ_FILESYSTEM)
 cmake_pop_check_state()


### PR DESCRIPTION
Two bugs configuring Cap'n Proto include directories were reported by sjors in https://github.com/chaincodelabs/libmultiprocess/issues/75

They appear to have gone undetected because they were masked in other contexts by `CMAKE_INCLUDE_PATH` and `NIX_CFLAGS_COMPILE` environment variable settings (https://github.com/chaincodelabs/libmultiprocess/issues/75#issuecomment-1262334271)

The first bug is missing `${CAPNP_INCLUDE_DIRECTORY}` target_include_directories in the `util` target. This resulted in a compile error `include/mp/util.h:8:10: fatal error: 'capnp/schema.h' file not found`

The second bug was misspelling `CAPNP_INCLUDE_DIRS` as `capnp_INCLUDE_DIRS` in the configure check for `kj/filesystem.h`, which caused `HAVE_KJ_FILESYSTEM` to be unset and could result in runtime errors like:

```bash
capnp compile: --import-path=/prefix/include: no such directory
Try 'capnp compile --help' for more information.
terminate called after throwing an instance of 'std::runtime_error'
  what():  Invoking capnp failed
```