### PR TITLE
Avoid passing some function arguments by value

### DIFF
--- a/example/calculator.cpp
+++ b/example/calculator.cpp
@@ -30,9 +30,9 @@ public:
     }
 };
 
-void LogPrint(bool raise, std::string message)
+void LogPrint(bool raise, const std::string& message)
 {
-    if (raise) throw std::runtime_error(std::move(message));
+    if (raise) throw std::runtime_error(message);
     std::ofstream("debug.log", std::ios_base::app) << message << std::endl;
 }
 

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -23,9 +23,9 @@ auto Spawn(mp::EventLoop& loop, const std::string& process_argv0, const std::str
     return std::make_tuple(mp::ConnectStream<InitInterface>(loop, fd), pid);
 }
 
-void LogPrint(bool raise, std::string message)
+void LogPrint(bool raise, const std::string& message)
 {
-    if (raise) throw std::runtime_error(std::move(message));
+    if (raise) throw std::runtime_error(message);
     std::ofstream("debug.log", std::ios_base::app) << message << std::endl;
 }
 

--- a/example/printer.cpp
+++ b/example/printer.cpp
@@ -24,9 +24,9 @@ public:
     std::unique_ptr<Printer> makePrinter() override { return std::make_unique<PrinterImpl>(); }
 };
 
-void LogPrint(bool raise, std::string message)
+void LogPrint(bool raise, const std::string& message)
 {
-    if (raise) throw std::runtime_error(std::move(message));
+    if (raise) throw std::runtime_error(message);
     std::ofstream("debug.log", std::ios_base::app) << message << std::endl;
 }
 

--- a/include/mp/proxy-types.h
+++ b/include/mp/proxy-types.h
@@ -159,7 +159,7 @@ auto PassField(Priority<1>, TypeList<>, ServerContext& server_context, const Fn&
 
     auto thread_client = context_arg.getThread();
     return JoinPromises(server.m_context.connection->m_threads.getLocalServer(thread_client)
-                            .then([&server, invoke, req](kj::Maybe<Thread::Server&> perhaps) {
+                            .then([&server, invoke, req](const kj::Maybe<Thread::Server&>& perhaps) {
                                 KJ_IF_MAYBE(thread_server, perhaps)
                                 {
                                     const auto& thread = static_cast<ProxyServer<Thread>&>(*thread_server);


### PR DESCRIPTION
Preemptively avoid clang-tidy errors before clang-tidy is introduced in https://github.com/chaincodelabs/libmultiprocess/pull/83. Other clang errors are already fixed in that PR, but these aren't maybe due to running different clang-tidy versions. The errors look like:

```c++
include/mp/proxy-types.h:162:85: warning: the parameter 'perhaps' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param]
                            .then([&server, invoke, req](kj::Maybe<Thread::Server&> perhaps) {
                                                                                    ^
                                                         const                     &
example/printer.cpp:27:39: warning: the parameter 'message' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param]
void LogPrint(bool raise, std::string message)
                                      ^
example/printer.cpp:29:41: warning: passing result of std::move() as a const reference argument; no move will actually happen [performance-move-const-arg]
    if (raise) throw std::runtime_error(std::move(message));
                                        ^~~~~~~~~~       ~
```