### PR TITLE
Remove naming requirement for std::pair/std::tuple

### DIFF
--- a/test/mp/test/foo.capnp
+++ b/test/mp/test/foo.capnp
@@ -44,7 +44,7 @@ struct FooCustom $Proxy.wrap("mp::test::FooCustom") {
     v2 @1 :Int32;
 }
 
-struct Pair(Key, Value) {
-    key @0 :Key;
-    value @1 :Value;
+struct Pair(T1, T2) {
+    first @0 :T1;
+    second @1 :T2;
 }


### PR DESCRIPTION
When converting C++ std::pair and length 2 std::tuple values to and from capn'proto structs, no longer require the struct to have fields named "key" and "value".  Instead always map the first pair/tuple element to the first struct field, and the second element to the second field.

This allows anonymous std::pair and std::tuple types used in the C++ interface to have names and custom Read/Build logic when they are serialized as capn'proto messages.

For now only length-2 tuples are supported but this could be extended to support converting c++ tuples of arbitrary length to capn'proto structs with the same number of fields.