### PR TITLE
pkgconfig: Drop -std=c++17 compile flag

### DIFF
--- a/pkgconfig/libmultiprocess.pc.in
+++ b/pkgconfig/libmultiprocess.pc.in
@@ -9,4 +9,4 @@ Description: Multiprocess IPC library
 Version: 0.0
 
 Libs: -L${libdir} -lmultiprocess -L${capnp_prefix}/lib -lcapnp-rpc -lcapnp -lkj-async -lkj -pthread -lpthread
-Cflags: -std=c++17 -I${includedir} -I${capnp_prefix}/include -pthread
+Cflags: -I${includedir} -I${capnp_prefix}/include -pthread


### PR DESCRIPTION
This compile flag was required previously when Bitcoin Core was using C++11, and libmultiprocess headers needed to be compiled with C++14 in order to be compatible with newer versions of Cap'n Proto. The flag was updated to C++17 since then.

But now Bitcoin Core has been updated to use C++20 and having the C++17 flag causes errors when the std::u8string type is referenced in bitcoin code. So just remove the C++ flag and let the application be responsible for choosing the C++ version.