### PR TITLE
pkgconfig: Use @CMAKE_INSTALL_LIBDIR@ variable

### DIFF
--- a/pkgconfig/libmultiprocess.pc.in
+++ b/pkgconfig/libmultiprocess.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/lib
-includedir=${prefix}/include
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 capnp_prefix=@capnp_PREFIX@
 
 Name: libmultiprocess


### PR DESCRIPTION
Use @CMAKE_INSTALL_LIBDIR@ variable instead of hardcoding "lib" as the libdir. This is needed after 54bd57fb3b064c7f3d556b015e8f64fd8d234c19 (https://github.com/chaincodelabs/libmultiprocess/pull/79) which changed the installation to sometimes install to "lib64".

This fixes error "ld: cannot find -lmultiprocess: No such file or directory" in Bitcoin Core.

Also replace hardcoded "include" with @CMAKE_INSTALL_INCLUDEDIR@ for consistency.