### PR TITLE
Fix support for vector<bool> serialization with libc++

### DIFF
--- a/include/mp/proxy-types.h
+++ b/include/mp/proxy-types.h
@@ -881,7 +881,7 @@ template <typename Value>
     return {};
 }
 
-inline static bool BuildPrimitive(InvokeContext& invoke_context, std::vector<bool>::reference value, TypeList<bool>)
+inline static bool BuildPrimitive(InvokeContext& invoke_context, std::vector<bool>::const_reference value, TypeList<bool>)
 {
     return value;
 }


### PR DESCRIPTION
The vector<bool> serialization supported added in https://github.com/chaincodelabs/libmultiprocess/pull/86 commit 1c6fb04dddfc0de35eb5952649fda83a030ff288 was only tested with libstdc++ not libc++ and caused a test compilation failure when compiling on macos, reported by edilmedeiros in https://github.com/chaincodelabs/libmultiprocess/issues/92

Fix the issue that was causing the build to fail: trying to use using vector's reference type instead of const_reference type when serializing the vector.

Fixes #92