### PR TITLE
doc: Document shutdown sequences better

### DIFF
--- a/include/mp/proxy-types.h
+++ b/include/mp/proxy-types.h
@@ -1434,6 +1434,9 @@ struct CapRequestTraits<::capnp::Request<_Params, _Results>>
     using Results = _Results;
 };
 
+//! Entry point called by all generated ProxyClient destructors. This only logs
+//! the object destruction. The actual cleanup happens in the ProxyClient base
+//! destructor.
 template <typename Client>
 void clientDestroy(Client& client)
 {


### PR DESCRIPTION
Improve comments describing proxy server and proxy client object shutdown sequences.

This also adds a new assert in ~ProxyServerBase()