### PR TITLE
cmake: Fix package configuration file

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -7,24 +7,24 @@
 set(_Libmultiprocess_supported_components Bin Lib)
 
 # If no components specified, include all components.
-list(LENGTH Libmultiprocess_FIND_COMPONENTS Libmultiprocess_FIND_COMPONENTS_len)
-if(Libmultiprocess_FIND_COMPONENTS_len EQUAL 0)
-    set(Libmultiprocess_FIND_COMPONENTS ${_Libmultiprocess_supported_components})
+list(LENGTH ${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS ${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS_len)
+if(${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS_len EQUAL 0)
+  set(${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS ${_Libmultiprocess_supported_components})
 endif()
 
-if ("Bin" IN_LIST Libmultiprocess_FIND_COMPONENTS)
+if ("Bin" IN_LIST ${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS)
   include("${CMAKE_CURRENT_LIST_DIR}/TargetCapnpSources.cmake")
 endif()
 
-if ("Lib" IN_LIST Libmultiprocess_FIND_COMPONENTS)
+if ("Lib" IN_LIST ${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS)
   include(CMakeFindDependencyMacro)
   find_dependency(CapnProto)
 endif()
 
-foreach(_comp ${Libmultiprocess_FIND_COMPONENTS})
+foreach(_comp ${${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS})
   if (NOT _comp IN_LIST _Libmultiprocess_supported_components)
-    set(Libmultiprocess_FOUND False)
-    set(Libmultiprocess_NOT_FOUND_MESSAGE "Unsupported component: ${_comp}")
+    set(${CMAKE_FIND_PACKAGE_NAME}_FOUND False)
+    set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE "Unsupported component: ${_comp}")
   endif()
   include("${CMAKE_CURRENT_LIST_DIR}/${_comp}Targets.cmake")
 endforeach()


### PR DESCRIPTION
When loading a package configuration file, `find_package` defines variables to provide information about the call arguments. In particular, `CMAKE_FIND_PACKAGE_NAME` represents the package name.

This PR uses this variable instead of a hardcoded name, making the use case suggested in https://github.com/chaincodelabs/libmultiprocess/pull/98#issuecomment-2243751206 workable:
```cmake
find_package(Libmultiprocess COMPONENTS Lib)
find_package(LibmultiprocessNative COMPONENTS Bin
  NAMES Libmultiprocess
)
```
