### PR TITLE
types: Add Custom{Build,Read,Pass}Message hooks

### DIFF
--- a/test/mp/test/foo-types.h
+++ b/test/mp/test/foo-types.h
@@ -28,6 +28,45 @@ decltype(auto) CustomReadField(TypeList<FooCustom>, Priority<1>, InvokeContext& 
 }
 
 } // namespace test
+
+inline void CustomBuildMessage(InvokeContext& invoke_context,
+                        const test::FooMessage& src,
+                        test::messages::FooMessage::Builder&& builder)
+{
+    builder.setMessage(src.message + " build");
+}
+
+inline void CustomReadMessage(InvokeContext& invoke_context,
+                       const test::messages::FooMessage::Reader& reader,
+                       test::FooMessage& dest)
+{
+    dest.message = std::string{reader.getMessage()} + " read";
+}
+
+inline void CustomBuildMessage(InvokeContext& invoke_context,
+                        const test::FooMutable& src,
+                        test::messages::FooMutable::Builder&& builder)
+{
+    builder.setMessage(src.message + " build");
+}
+
+inline void CustomReadMessage(InvokeContext& invoke_context,
+                       const test::messages::FooMutable::Reader& reader,
+                       test::FooMutable& dest)
+{
+    dest.message = std::string{reader.getMessage()} + " read";
+}
+
+inline void CustomPassMessage(InvokeContext& invoke_context,
+                       const test::messages::FooMutable::Reader& reader,
+                       test::messages::FooMutable::Builder builder,
+                       std::function<void(test::FooMutable&)>&& fn)
+{
+    test::FooMutable mut;
+    mut.message = std::string{reader.getMessage()} + " pass";
+    fn(mut);
+    builder.setMessage(mut.message + " return");
+}
 } // namespace mp
 
 #endif // MP_TEST_FOO_TYPES_H

--- a/test/mp/test/foo.capnp
+++ b/test/mp/test/foo.capnp
@@ -25,6 +25,8 @@ interface FooInterface $Proxy.wrap("mp::test::FooImplementation") {
     callbackExtended @10 (context :Proxy.Context, callback :ExtendedCallback, arg: Int32) -> (result :Int32);
     passCustom @11 (arg :FooCustom) -> (result :FooCustom);
     passEmpty @12 (arg :FooEmpty) -> (result :FooEmpty);
+    passMessage @13 (arg :FooMessage) -> (result :FooMessage);
+    passMutable @14 (arg :FooMutable) -> (arg :FooMutable);
 }
 
 interface FooCallback $Proxy.wrap("mp::test::FooCallback") {
@@ -48,6 +50,14 @@ struct FooCustom $Proxy.wrap("mp::test::FooCustom") {
 }
 
 struct FooEmpty $Proxy.wrap("mp::test::FooEmpty") {
+}
+
+struct FooMessage {
+    message @0 :Text;
+}
+
+struct FooMutable {
+    message @0 :Text;
 }
 
 struct Pair(T1, T2) {

--- a/test/mp/test/foo.h
+++ b/test/mp/test/foo.h
@@ -31,6 +31,16 @@ struct FooEmpty
 {
 };
 
+struct FooMessage
+{
+    std::string message;
+};
+
+struct FooMutable
+{
+    std::string message;
+};
+
 class FooCallback
 {
 public:
@@ -60,6 +70,8 @@ public:
     int callbackExtended(ExtendedCallback& callback, int arg) { return callback.callExtended(arg); }
     FooCustom passCustom(FooCustom foo) { return foo; }
     FooEmpty passEmpty(FooEmpty foo) { return foo; }
+    FooMessage passMessage(FooMessage foo) { foo.message += " call"; return foo; }
+    void passMutable(FooMutable& foo) { foo.message += " call"; }
     std::shared_ptr<FooCallback> m_callback;
 };
 

--- a/test/mp/test/test.cpp
+++ b/test/mp/test/test.cpp
@@ -108,6 +108,16 @@ KJ_TEST("Call FooInterface methods")
 
     foo->passEmpty(FooEmpty{});
 
+    FooMessage message1;
+    message1.message = "init";
+    FooMessage message2{foo->passMessage(message1)};
+    KJ_EXPECT(message2.message == "init build read call build read");
+
+    FooMutable mut;
+    mut.message = "init";
+    foo->passMutable(mut);
+    KJ_EXPECT(mut.message == "init build pass call return read");
+
     disconnect_client();
     thread.join();
 


### PR DESCRIPTION
Add `CustomBuildMessage`, `CustomReadMessage`, and `CustomPassMessage` hook functions. These functions can be defined to use custom code to convert C++ objects to and from Cap'n Proto messages. They work similarly to existing `CustomBuildField`, `CustomReadField,` and `CustomPassField` hooks, except they can be defined as normal functions not template functions, so they should be easier to use and require less verbosity in most cases, although they are less flexible.

The unit tests added here are new but the feature was originally implemented in https://github.com/bitcoin/bitcoin/pull/10102 but and is being ported because it's a general purpose feature.