### PR TITLE
example: Remove manual client adding

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -39,10 +39,6 @@ int main(int argc, char** argv)
     std::promise<mp::EventLoop*> promise;
     std::thread loop_thread([&] {
         mp::EventLoop loop("mpexample", LogPrint);
-        {
-            std::unique_lock<std::mutex> lock(loop.m_mutex);
-            loop.addClient(lock);
-        }
         promise.set_value(&loop);
         loop.loop();
     });


### PR DESCRIPTION
Opening this more as a question, than a change request, because I am not sure what is going on here, since removing it does not seem to change anything in the program's functionality.

This is probably needed, but it is not clear from the example, or the documentation for what. If it is indeed needed, could the documentation be improved a bit, a comment added to the example or could it alternatively be moved into the `EventLoop` constructor instead? From my understanding `addClient` is eventually called internally when a new connection or proxy is created. 