### PR TITLE
doc: Add comments for socket descriptor handling when forking

### DIFF
--- a/src/mp/util.cpp
+++ b/src/mp/util.cpp
@@ -110,10 +110,12 @@ int SpawnProcess(int& pid, FdToArgsFn&& fd_to_args)
     if (pid == -1) {
         throw std::system_error(errno, std::system_category(), "fork");
     }
+    // Parent process closes the descriptor for socket 0, child closes the descriptor for socket 1.
     if (close(fds[pid ? 0 : 1]) != 0) {
         throw std::system_error(errno, std::system_category(), "close");
     }
     if (!pid) {
+        // Child process must close all potentially open descriptors, except socket 0.
         int maxFd = MaxFd();
         for (int fd = 3; fd < maxFd; ++fd) {
             if (fd != fds[0]) {


### PR DESCRIPTION
I find logic around forking child processes always a bit confusing, hopefully these comments can make it a bit easier for a future reader.