### PR TITLE
Add missing include to util.h

### DIFF
--- a/include/mp/util.h
+++ b/include/mp/util.h
@@ -7,6 +7,7 @@
 
 #include <capnp/schema.h>
 #include <cstddef>
+#include <functional>
 #include <future>
 #include <kj/common.h>
 #include <kj/exception.h>


### PR DESCRIPTION
Fixes:
```bash
mp/util.h:207:20: error: no template named 'function' in namespace 'std'; did you mean 'kj::Function'?
  207 | using FdToArgsFn = std::function<std::vector<std::string>(int fd)>;
      |                    ^~~~~~~~~~~~~
      |                    kj::Function
```
when compiling with libc++ & `_LIBCPP_REMOVE_TRANSITIVE_INCLUDES`.