### PR TITLE
shutdown bugfix: Prevent segfault in server if connection is broken during long function call

### DIFF
--- a/src/mp/proxy.cpp
+++ b/src/mp/proxy.cpp
@@ -277,6 +277,11 @@ std::tuple<ConnThread, bool> SetThread(ConnThreads& threads, std::mutex& mutex, 
         std::piecewise_construct, std::forward_as_tuple(connection),
         std::forward_as_tuple(make_thread(), connection, /* destroy_connection= */ false)).first;
     thread->second.setCleanup([&threads, &mutex, thread] {
+        // Note: it is safe to use the `thread` iterator in this cleanup
+        // function, because the iterator would only be invalid if the map entry
+        // was removed, and if the map entry is removed the ProxyClient<Thread>
+        // destructor unregisters the cleanup.
+
         // Connection is being destroyed before thread client is, so reset
         // thread client m_cleanup member so thread client destructor does not
         // try unregister this callback after connection is destroyed.


### PR DESCRIPTION
Fix issue where if a client disconnects in the middle of a long running IPC method call, the server will segfault when the method eventually returns.

This issue was reported tdb3 in https://github.com/bitcoin/bitcoin/pull/31003#pullrequestreview-2349619672 with a stack trace showing where the crash happens in the `PassField` `mp.Context` overload while calling `request_threads.erase`.