### PR TITLE
cmake: avoid libatomic not found error on debian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ project("Libmultiprocess" CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
+include("cmake/compat_find.cmake")
+
 find_package(CapnProto REQUIRED)
 find_package(Threads REQUIRED)
 
@@ -20,7 +22,7 @@ if(Libmultiprocess_ENABLE_CLANG_TIDY)
   set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXECUTABLE}")
 endif()
 
-include("cmake/capnp_compat.cmake")
+include("cmake/compat_config.cmake")
 include("cmake/pthread_checks.cmake")
 include(GNUInstallDirs)
 

--- a/cmake/compat_config.cmake
+++ b/cmake/compat_config.cmake
@@ -2,6 +2,9 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+# compat_config.cmake -- compatibility workarounds meant to be included after
+# cmake find_package() calls are made, before configuring the ebuild
+
 # Define capnp_PREFIX if not defined to avoid issue on macos
 # https://github.com/chaincodelabs/libmultiprocess/issues/26
 

--- a/cmake/compat_find.cmake
+++ b/cmake/compat_find.cmake
@@ -1,0 +1,20 @@
+# Copyright (c) 2024 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# compat_find.cmake -- compatibility workarounds meant to be included before
+# cmake find_package() calls are made
+
+# Set FOUND_LIBATOMIC to work around bug in debian capnproto package that is
+# debian-specific and does not happpen upstream. Debian includes a patch
+# https://sources.debian.org/patches/capnproto/1.0.1-4/07_libatomic.patch/ which
+# uses check_library_exists(atomic __atomic_load_8 ...) and it fails because the
+# symbol name conflicts with a compiler instrinsic as described
+# https://github.com/chaincodelabs/libmultiprocess/issues/68#issuecomment-1135150171.
+# This could be fixed by improving the check_library_exists function as
+# described in the github comment, or by changing the debian patch to check for
+# the symbol a different way, but simplest thing to do is work around the
+# problem by setting FOUND_LIBATOMIC. This problem has probably not
+# been noticed upstream because it only affects CMake packages depending on
+# capnproto, not autoconf packages.
+set(FOUND_LIBATOMIC TRUE)


### PR DESCRIPTION
Add workaround to prevent "libatomic not found" when building on debian against debian capnproto package which installs a buggy CapnProtoConfig.cmake file. The bug was introduced as part of debian's attempt to fix a different issue: https://github.com/capnproto/capnproto/issues/1448 and their fix works for autoconf projects but not cmake projects like libmultiprocess.

Fixes #68