### PR TITLE
proxy-types.h: add static_assert to detect int/enum size mismatch

### DIFF
--- a/include/mp/proxy-types.h
+++ b/include/mp/proxy-types.h
@@ -963,6 +963,9 @@ LocalType BuildPrimitive(InvokeContext& invoke_context,
     TypeList<LocalType>,
     typename std::enable_if<std::is_enum<Value>::value>::type* enable = nullptr)
 {
+    using E = std::make_unsigned_t<std::underlying_type_t<Value>>;
+    using T = std::make_unsigned_t<LocalType>;
+    static_assert(std::numeric_limits<T>::max() >= std::numeric_limits<E>::max(), "mismatched integral/enum types");
     return static_cast<LocalType>(value);
 }
 

--- a/test/mp/test/foo.capnp
+++ b/test/mp/test/foo.capnp
@@ -27,6 +27,7 @@ interface FooInterface $Proxy.wrap("mp::test::FooImplementation") {
     passEmpty @12 (arg :FooEmpty) -> (result :FooEmpty);
     passMessage @13 (arg :FooMessage) -> (result :FooMessage);
     passMutable @14 (arg :FooMutable) -> (arg :FooMutable);
+    passEnum @15 (arg :Int32) -> (result :Int32);
 }
 
 interface FooCallback $Proxy.wrap("mp::test::FooCallback") {

--- a/test/mp/test/foo.h
+++ b/test/mp/test/foo.h
@@ -21,6 +21,8 @@ struct FooStruct
     std::vector<bool> vbool;
 };
 
+enum class FooEnum : int { ONE = 1, TWO = 2, };
+
 struct FooCustom
 {
     std::string v1;
@@ -72,6 +74,7 @@ public:
     FooEmpty passEmpty(FooEmpty foo) { return foo; }
     FooMessage passMessage(FooMessage foo) { foo.message += " call"; return foo; }
     void passMutable(FooMutable& foo) { foo.message += " call"; }
+    FooEnum passEnum(FooEnum foo) { return foo; }
     std::shared_ptr<FooCallback> m_callback;
 };
 


### PR DESCRIPTION
Add static_assert to detect when an int field is too small to hold an enum value

This catches the bug TheCharlatan pointed out in https://github.com/bitcoin/bitcoin/pull/29409#discussion_r1834362068