### PR TITLE
ProxyClientBase: avoid static_cast to partially constructed object

### DIFF
--- a/include/mp/proxy-io.h
+++ b/include/mp/proxy-io.h
@@ -432,7 +432,6 @@ ProxyClientBase<Interface, Impl>::ProxyClientBase(typename Interface::Client cli
         });
     }
     });
-    self().construct();
 }
 
 template <typename Interface, typename Impl>

--- a/src/mp/gen.cpp
+++ b/src/mp/gen.cpp
@@ -357,7 +357,8 @@ void Generate(kj::StringPtr src_prefix,
             client << "public ProxyClientCustom<" << message_namespace << "::" << node_name << ", "
                    << proxied_class_type << ">\n{\n";
             client << "public:\n";
-            client << "    using ProxyClientCustom::ProxyClientCustom;\n";
+            client << "    template <typename... Args>\n";
+            client << "    ProxyClient(Args&&... args) : ProxyClientCustom(std::forward<Args>(args)...) { construct(); }\n";
             client << "    ~ProxyClient();\n";
 
             std::ostringstream server;


### PR DESCRIPTION
`ProxyClientBase` constructor was trying to call `ProxyClient::construct()` method before `ProxyClient` object had been fully constructed. This is causing a UBSAN error reported:

- https://github.com/bitcoin/bitcoin/pull/30975#issuecomment-2511204009
- https://github.com/bitcoin/bitcoin/actions/runs/11970857809/job/33374462331?pr=30975

that looks like:

```c++
include/mp/proxy.h:95:45: runtime error: downcast of address 0x50600002bdc0 which does not point to an object of type 'ProxyClient<Interface>' (aka 'ProxyClient<ipc::capnp::messages::Init>')
0x50600002bdc0: note: object is of type 'mp::ProxyClientBase<ipc::capnp::messages::Init, interfaces::Init>'
```