### PR TITLE
ProxyClientBase: avoid static_cast to partially destructed object

### DIFF
--- a/include/mp/proxy-io.h
+++ b/include/mp/proxy-io.h
@@ -435,12 +435,6 @@ ProxyClientBase<Interface, Impl>::ProxyClientBase(typename Interface::Client cli
 }
 
 template <typename Interface, typename Impl>
-ProxyClientBase<Interface, Impl>::~ProxyClientBase() noexcept
-{
-    CleanupRun(m_context.cleanup_fns);
-}
-
-template <typename Interface, typename Impl>
 ProxyServerBase<Interface, Impl>::ProxyServerBase(std::shared_ptr<Impl> impl, Connection& connection)
     : m_impl(std::move(impl)), m_context(&connection)
 {

--- a/include/mp/proxy-types.h
+++ b/include/mp/proxy-types.h
@@ -1532,17 +1532,18 @@ struct CapRequestTraits<::capnp::Request<_Params, _Results>>
     using Results = _Results;
 };
 
-//! Entry point called by all generated ProxyClient destructors. This only logs
-//! the object destruction. The actual cleanup happens in the ProxyClient base
-//! destructor.
+//! Entry point called by all generated ProxyClient destructors.
 template <typename Client>
 void clientDestroy(Client& client)
 {
+    // Log that ProxyClient object is being destroyed.
     if (client.m_context.connection) {
         client.m_context.connection->m_loop.log() << "IPC client destroy " << typeid(client).name();
     } else {
         KJ_LOG(INFO, "IPC interrupted client destroy", typeid(client).name());
     }
+    // Call ProxyClientBase cleanup.
+    client.cleanup();
 }
 
 template <typename Server>

--- a/include/mp/proxy.h
+++ b/include/mp/proxy.h
@@ -39,11 +39,17 @@ struct ProxyType;
 using CleanupList = std::list<std::function<void()>>;
 using CleanupIt = typename CleanupList::iterator;
 
+inline void CleanupRun(CleanupList& fns) {
+    for (auto& fn : fns) {
+        fn();
+    }
+}
+
 //! Context data associated with proxy client and server classes.
 struct ProxyContext
 {
     Connection* connection;
-    std::list<std::function<void()>> cleanup;
+    CleanupList cleanup_fns;
 
     ProxyContext(Connection* connection) : connection(connection) {}
 };
@@ -147,7 +153,7 @@ public:
 //! state can be destroyed without blocking, because ProxyServer destructors are
 //! called from the EventLoop thread, and if they block, it could deadlock the
 //! program. One way to do avoid blocking is to clean up the state by pushing
-//! cleanup callbacks to the m_context.cleanup list, which run after the server
+//! cleanup callbacks to the m_context.cleanup_fns list, which run after the server
 //! m_impl object is destroyed on the same thread destroying it (which will
 //! either be an IPC worker thread if the ProxyServer is being explicitly
 //! destroyed by a client calling a destroy() method with a Context argument and

--- a/src/mp/proxy.cpp
+++ b/src/mp/proxy.cpp
@@ -283,9 +283,9 @@ std::tuple<ConnThread, bool> SetThread(ConnThreads& threads, std::mutex& mutex, 
         // destructor unregisters the cleanup.
 
         // Connection is being destroyed before thread client is, so reset
-        // thread client m_cleanup member so thread client destructor does not
+        // thread client m_cleanup_it member so thread client destructor does not
         // try unregister this callback after connection is destroyed.
-        thread->second.m_cleanup.reset();
+        thread->second.m_cleanup_it.reset();
         // Remove connection pointer about to be destroyed from the map
         std::unique_lock<std::mutex> lock(mutex);
         threads.erase(thread);
@@ -295,16 +295,16 @@ std::tuple<ConnThread, bool> SetThread(ConnThreads& threads, std::mutex& mutex, 
 
 ProxyClient<Thread>::~ProxyClient()
 {
-    if (m_cleanup) {
-        m_context.connection->removeSyncCleanup(*m_cleanup);
+    if (m_cleanup_it) {
+        m_context.connection->removeSyncCleanup(*m_cleanup_it);
     }
 }
 
-void ProxyClient<Thread>::setCleanup(std::function<void()> cleanup)
+void ProxyClient<Thread>::setCleanup(std::function<void()> fn)
 {
-    assert(cleanup);
-    assert(!m_cleanup);
-    m_cleanup = m_context.connection->addSyncCleanup(cleanup);
+    assert(fn);
+    assert(!m_cleanup_it);
+    m_cleanup_it = m_context.connection->addSyncCleanup(fn);
 }
 
 ProxyServer<Thread>::ProxyServer(ThreadContext& thread_context, std::thread&& thread)

--- a/src/mp/proxy.cpp
+++ b/src/mp/proxy.cpp
@@ -295,9 +295,14 @@ std::tuple<ConnThread, bool> SetThread(ConnThreads& threads, std::mutex& mutex, 
 
 ProxyClient<Thread>::~ProxyClient()
 {
+    // If thread is being destroyed before connection is destroyed, remove the
+    // cleanup callback that was registered to handle the connection being
+    // destroyed before the thread being destroyed.
     if (m_cleanup_it) {
         m_context.connection->removeSyncCleanup(*m_cleanup_it);
     }
+    // Call ProxyClientBase cleanup.
+    cleanup();
 }
 
 void ProxyClient<Thread>::setCleanup(std::function<void()> fn)

--- a/test/mp/test/test.cpp
+++ b/test/mp/test/test.cpp
@@ -122,7 +122,7 @@ KJ_TEST("Call FooInterface methods")
     thread.join();
 
     bool destroyed = false;
-    foo->m_context.cleanup.emplace_front([&destroyed]{ destroyed = true; });
+    foo->m_context.cleanup_fns.emplace_front([&destroyed]{ destroyed = true; });
     foo.reset();
     KJ_EXPECT(destroyed);
 }


### PR DESCRIPTION
This is a bugfix that should fix the UBSan failure reported https://github.com/chaincodelabs/libmultiprocess/issues/125

In practice there is no real bug here, just like there was no real bug fixed in the recent "ProxyClientBase: avoid static_cast to partially constructed object" change in https://github.com/chaincodelabs/libmultiprocess/pull/121. This is because in practice, ProxyClient subclasses only inherit ProxyClientBase state and do not define any state of their own, so there is nothing bad that could actually happen from static_cast-ing a ProxyClientBase pointer to a ProxyClient pointer inside the ProxyClientBase constructor or destructor.

However, using static_cast this way technically triggers undefined behavior, and that causes UBSan to fail, so this commit moves ProxyClientBase cleanup out of the ProxyClientBase destructor, into ProxyClient subclass destructors to prevent this.

An alternate fix could maybe avoid the need to do this by making ProxyClient::construct() and ProxyClient::destroy() methods into static methods taking a ProxyClientBase& self argument instead of instance methods using *this. This would avoid the need to use static_cast at all. But it would also require changes to the ProxyClient class code generator so unclear if it would be a simpler fix.

Fixes #125
