### PR TITLE
ProxyClientBase: avoid static_cast to partially destructed object

### DIFF
--- a/include/mp/proxy-io.h
+++ b/include/mp/proxy-io.h
@@ -382,7 +382,7 @@ ProxyClientBase<Interface, Impl>::ProxyClientBase(typename Interface::Client cli
     auto cleanup = m_context.connection->addSyncCleanup([this]() {
         // Release client capability by move-assigning to temporary.
         {
-            typename Interface::Client(std::move(self().m_client));
+            typename Interface::Client(std::move(m_client));
         }
         {
             std::unique_lock<std::mutex> lock(m_context.connection->m_loop.m_mutex);
@@ -412,13 +412,13 @@ ProxyClientBase<Interface, Impl>::ProxyClientBase(typename Interface::Client cli
         // the remote object, waiting for it to be deleted server side. If the
         // capnp interface does not define a destroy method, this will just call
         // an empty stub defined in the ProxyClientBase class and do nothing.
-        self().destroy();
+        Sub::destroy(*this);
 
         // FIXME: Could just invoke removed addCleanup fn here instead of duplicating code
         m_context.connection->m_loop.sync([&]() {
             // Release client capability by move-assigning to temporary.
             {
-                typename Interface::Client(std::move(self().m_client));
+                typename Interface::Client(std::move(m_client));
             }
             {
                 std::unique_lock<std::mutex> lock(m_context.connection->m_loop.m_mutex);
@@ -432,6 +432,7 @@ ProxyClientBase<Interface, Impl>::ProxyClientBase(typename Interface::Client cli
         });
     }
     });
+    Sub::construct(*this);
 }
 
 template <typename Interface, typename Impl>

--- a/include/mp/proxy.h
+++ b/include/mp/proxy.h
@@ -56,6 +56,8 @@ class ProxyClientBase : public Impl_
 public:
     using Interface = Interface_;
     using Impl = Impl_;
+    using Sub = ProxyClient<Interface>;
+    using Super = ProxyClientBase<Interface, Impl>;
 
     ProxyClientBase(typename Interface::Client client, Connection* connection, bool destroy_connection);
     ~ProxyClientBase() noexcept;
@@ -89,10 +91,8 @@ public:
     // then it will also ensure that the destructor runs on the same thread the
     // client used to make other RPC calls, instead of running on the server
     // EventLoop thread and possibly blocking it.
-    void construct() {}
-    void destroy() {}
-
-    ProxyClient<Interface>& self() { return static_cast<ProxyClient<Interface>&>(*this); }
+    static void construct(Super&) {}
+    static void destroy(Super&) {}
 
     typename Interface::Client m_client;
     ProxyContext m_context;


### PR DESCRIPTION
This is a bugfix that should fix the UBSan failure reported https://github.com/chaincodelabs/libmultiprocess/issues/125

In practice there is no real bug here, just like there was no real bug fixed in the recent "ProxyClientBase: avoid static_cast to partially constructed object" change in https://github.com/chaincodelabs/libmultiprocess/pull/121. This is because in practice, ProxyClient subclasses only inherit ProxyClientBase state and do not define any state of their own, so there is nothing bad that could actually happen from static_cast-ing a ProxyClientBase pointer to a ProxyClient pointer inside the ProxyClientBase constructor or destructor.

However, using static_cast this way technically triggers undefined behavior, and that causes UBSan to fail, so this commit drops the static_cast by making ProxyClient::construct() and ProxyClient::destroy() methods into static methods taking a ProxyClientBase& argument instead of instance methods using *this.

Fixes #125

---

This PR should be a simpler, more robust alternative to a previous for the same bug implemented in #126.