### PR TITLE
refactor: Add CleanupRun function to dedup clean list code

### DIFF
--- a/include/mp/proxy.h
+++ b/include/mp/proxy.h
@@ -39,11 +39,19 @@ struct ProxyType;
 using CleanupList = std::list<std::function<void()>>;
 using CleanupIt = typename CleanupList::iterator;
 
+inline void CleanupRun(CleanupList& fns) {
+    while (!fns.empty()) {
+        auto fn = std::move(fns.front());
+        fns.pop_front();
+        fn();
+    }
+}
+
 //! Context data associated with proxy client and server classes.
 struct ProxyContext
 {
     Connection* connection;
-    std::list<std::function<void()>> cleanup;
+    CleanupList cleanup_fns;
 
     ProxyContext(Connection* connection) : connection(connection) {}
 };
@@ -147,7 +155,7 @@ public:
 //! state can be destroyed without blocking, because ProxyServer destructors are
 //! called from the EventLoop thread, and if they block, it could deadlock the
 //! program. One way to do avoid blocking is to clean up the state by pushing
-//! cleanup callbacks to the m_context.cleanup list, which run after the server
+//! cleanup callbacks to the m_context.cleanup_fns list, which run after the server
 //! m_impl object is destroyed on the same thread destroying it (which will
 //! either be an IPC worker thread if the ProxyServer is being explicitly
 //! destroyed by a client calling a destroy() method with a Context argument and

--- a/src/mp/proxy.cpp
+++ b/src/mp/proxy.cpp
@@ -283,9 +283,9 @@ std::tuple<ConnThread, bool> SetThread(ConnThreads& threads, std::mutex& mutex, 
         // destructor unregisters the cleanup.
 
         // Connection is being destroyed before thread client is, so reset
-        // thread client m_cleanup member so thread client destructor does not
+        // thread client m_cleanup_it member so thread client destructor does not
         // try unregister this callback after connection is destroyed.
-        thread->second.m_cleanup.reset();
+        thread->second.m_cleanup_it.reset();
         // Remove connection pointer about to be destroyed from the map
         std::unique_lock<std::mutex> lock(mutex);
         threads.erase(thread);
@@ -295,16 +295,19 @@ std::tuple<ConnThread, bool> SetThread(ConnThreads& threads, std::mutex& mutex, 
 
 ProxyClient<Thread>::~ProxyClient()
 {
-    if (m_cleanup) {
-        m_context.connection->removeSyncCleanup(*m_cleanup);
+    // If thread is being destroyed before connection is destroyed, remove the
+    // cleanup callback that was registered to handle the connection being
+    // destroyed before the thread being destroyed.
+    if (m_cleanup_it) {
+        m_context.connection->removeSyncCleanup(*m_cleanup_it);
     }
 }
 
-void ProxyClient<Thread>::setCleanup(std::function<void()> cleanup)
+void ProxyClient<Thread>::setCleanup(std::function<void()> fn)
 {
-    assert(cleanup);
-    assert(!m_cleanup);
-    m_cleanup = m_context.connection->addSyncCleanup(cleanup);
+    assert(fn);
+    assert(!m_cleanup_it);
+    m_cleanup_it = m_context.connection->addSyncCleanup(fn);
 }
 
 ProxyServer<Thread>::ProxyServer(ThreadContext& thread_context, std::thread&& thread)

--- a/test/mp/test/test.cpp
+++ b/test/mp/test/test.cpp
@@ -122,7 +122,7 @@ KJ_TEST("Call FooInterface methods")
     thread.join();
 
     bool destroyed = false;
-    foo->m_context.cleanup.emplace_front([&destroyed]{ destroyed = true; });
+    foo->m_context.cleanup_fns.emplace_front([&destroyed]{ destroyed = true; });
     foo.reset();
     KJ_EXPECT(destroyed);
 }


### PR DESCRIPTION
Add CleanupRun function to dedup clean list code. Also rename "cleanup" variables to distinguish between cleanup iterators and cleanup callback functions.

These changes were originally part of https://github.com/chaincodelabs/libmultiprocess/pull/126 which was closed for other reasons, but I think they are still helpful and make code easier to navigate.

Since this renames a public struct member, it will require a change to bitcoin core when the depends version is bumped:

```c++
diff --git a/src/ipc/capnp/protocol.cpp b/src/ipc/capnp/protocol.cpp
index 4b67a5bd1e36..691bdf5f9242 100644
--- a/src/ipc/capnp/protocol.cpp
+++ b/src/ipc/capnp/protocol.cpp
@@ -73,7 +73,7 @@ public:
     }
     void addCleanup(std::type_index type, void* iface, std::function<void()> cleanup) override
     {
-        mp::ProxyTypeRegister::types().at(type)(iface).cleanup.emplace_back(std::move(cleanup));
+        mp::ProxyTypeRegister::types().at(type)(iface).cleanup_fns.emplace_back(std::move(cleanup));
     }
     Context& context() override { return m_context; }
     void startLoop(const char* exe_name)
```