### PR TITLE
Fix debian "libatomic not found" error in downstream builds

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -17,6 +17,9 @@ if ("Bin" IN_LIST ${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS)
 endif()
 
 if ("Lib" IN_LIST ${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS)
+  # Setting FOUND_LIBATOMIC is needed on debian & ubuntu systems to work around bug in
+  # their capnproto packages. See compat_find.cmake for a more complete explanation.
+  set(FOUND_LIBATOMIC TRUE)
   include(CMakeFindDependencyMacro)
   find_dependency(CapnProto)
 endif()


### PR DESCRIPTION
This is an extension of the workaround implemented previously in #119. That workaround let the libmultiprocess cmake build work with the debian capnproto package.

This change extends the workaround to apply to downstream cmake builds that call find_package(Libmultiprocess), like Bitcoin Core.

Fixes #132