### PR TITLE
build: don't clobber user/superproject c++ version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,10 @@
 cmake_minimum_required(VERSION 3.8)
 
 project("Libmultiprocess" CXX)
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED YES)
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED YES)
+endif()
 
 include("cmake/compat_find.cmake")
 


### PR DESCRIPTION
This allows a vendored libmultiprocess to inherit the c++ version from the main project