### PR TITLE
build: Fix for vendored subdir in Bitcoin Core when using depends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,9 +97,18 @@ target_include_directories(multiprocess PUBLIC
 target_include_directories(multiprocess SYSTEM PUBLIC
   $<BUILD_INTERFACE:${CAPNP_INCLUDE_DIRECTORY}>
 )
-target_include_directories(multiprocess SYSTEM PUBLIC
-  $<INSTALL_INTERFACE:${CAPNP_INCLUDE_DIRECTORY}>
-)
+
+# Hack to avoid exporting a path "which is prefixed in the source directory".
+# If we're in another project's subdir and capnp is installed somewhere inside
+# that project (as it is with depends in Bicoin Core) CMake refuses to allow it
+# in the install interface. Use the "EXCLUDE_FROM_ALL" property as a proxy for
+# detecting this condition, as in that case install won't happen anyway.
+get_directory_property(mp_skip_install EXCLUDE_FROM_ALL)
+if(NOT "${mp_skip_install}")
+  target_include_directories(multiprocess SYSTEM PUBLIC
+    $<INSTALL_INTERFACE:${CAPNP_INCLUDE_DIRECTORY}>
+  )
+endif()
 
 target_link_libraries(multiprocess PRIVATE CapnProto::capnp)
 target_link_libraries(multiprocess PRIVATE CapnProto::capnp-rpc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,15 @@ target_include_directories(multiprocess PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-  ${CAPNP_INCLUDE_DIRECTORY})
+)
+
+target_include_directories(multiprocess SYSTEM PUBLIC
+  $<BUILD_INTERFACE:${CAPNP_INCLUDE_DIRECTORY}>
+)
+target_include_directories(multiprocess SYSTEM PUBLIC
+  $<INSTALL_INTERFACE:${CAPNP_INCLUDE_DIRECTORY}>
+)
+
 target_link_libraries(multiprocess PRIVATE CapnProto::capnp)
 target_link_libraries(multiprocess PRIVATE CapnProto::capnp-rpc)
 target_link_libraries(multiprocess PRIVATE CapnProto::kj)


### PR DESCRIPTION
This is a really wonky issue (it took me quite a while to figure out why it was complaining). It works around a quirk path issue that presents itself when using libmultiprocess as a subdir of Core and using a depends-built capnproto within the same source tree:

```
CMake Error in src/ipc/libmultiprocess/CMakeLists.txt:
  Target "multiprocess" INTERFACE_INCLUDE_DIRECTORIES property contains path:

    "/home/cory/dev/bitcoin/depends/x86_64-pc-linux-gnu/include"

  which is prefixed in the source directory.

```

It doesn't present in https://github.com/bitcoin/bitcoin/pull/31741 because in that case, the lib is built in depends rather than as part of the source tree.

This is part of my work to always build from the source tree rather than from depends. I can push up the other changes (the `EXTERNAL_MPGEN` option )needed for that, but I wanted to break this one out in case it needed further discussion/explanation. It's safe to go in as-is though, it should just be a no-op.

While I was at it, because the capnp headers spew annoying and harmless warnings when built with Core's flags turned on, I marked them as `SYSTEM`.

See the commit description for more details.