### PR TITLE
build: add option for external mpgen binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ if(Libmultiprocess_ENABLE_CLANG_TIDY)
   set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXECUTABLE}")
 endif()
 
+set(EXTERNAL_MPGEN "" CACHE STRING "Use the supplied mpgen binary rather than the one built internally")
+
 include("cmake/compat_config.cmake")
 include("cmake/pthread_checks.cmake")
 include(GNUInstallDirs)

--- a/cmake/TargetCapnpSources.cmake
+++ b/cmake/TargetCapnpSources.cmake
@@ -60,15 +60,23 @@ function(target_capnp_sources target include_prefix)
     "IMPORT_PATHS"  # multi_value_keywords
   )
 
-  if(NOT TARGET Libmultiprocess::mpgen)
-    message(FATAL_ERROR "Target 'Libmultiprocess::mpgen' does not exist.")
+  set(MPGEN_BINARY "")
+  if(EXTERNAL_MPGEN)
+    set(MPGEN_BINARY "${EXTERNAL_MPGEN}")
+    if(NOT EXISTS "${MPGEN_BINARY}")
+      message(FATAL_ERROR "EXTERNAL_MPGEN: \"${MPGEN_BINARY}\" does not exist.")
+    endif()
+  elseif(TARGET Libmultiprocess::multiprocess)
+    set(MPGEN_BINARY $<TARGET_FILE:Libmultiprocess::mpgen>)
+  else()
+    message(FATAL_ERROR "No usable mpgen. Set EXTERNAL_MPGEN or enable the internal target.")
   endif()
 
   set(generated_headers "")
   foreach(capnp_file IN LISTS TCS_UNPARSED_ARGUMENTS)
     add_custom_command(
       OUTPUT ${capnp_file}.c++ ${capnp_file}.h ${capnp_file}.proxy-client.c++ ${capnp_file}.proxy-types.h ${capnp_file}.proxy-server.c++ ${capnp_file}.proxy-types.c++ ${capnp_file}.proxy.h
-      COMMAND Libmultiprocess::mpgen ${CMAKE_CURRENT_SOURCE_DIR} ${include_prefix} ${CMAKE_CURRENT_SOURCE_DIR}/${capnp_file} ${TCS_IMPORT_PATHS} ${MP_INCLUDE_DIR}
+      COMMAND ${MPGEN_BINARY} ${CMAKE_CURRENT_SOURCE_DIR} ${include_prefix} ${CMAKE_CURRENT_SOURCE_DIR}/${capnp_file} ${TCS_IMPORT_PATHS} ${MP_INCLUDE_DIR}
       DEPENDS ${capnp_file}
       VERBATIM
     )


### PR DESCRIPTION
The parent project or user can supply `EXTERNAL_MPGEN`, which will override the one set here. If not set, the internally built one is used instead.

This is useful for cross builds, especially when using libmultiprocess as a subdirectory. Parent projects can similarly define a cache var.

Note that the internal binary is still built, but it can be skipped by building the multiprocess target directly.

This is the simplest impl of this I could come up with. Trying to pass an optional option for the binary into `target_capnp_sources` is not very ergonomic with CMake, so I've opted for just using a global here instead.

It would probably make sense to disable the internal mpgen target if the external option is used, but that adds a good bit of complexity, so I haven't done it here. Happy to do it as a follow-up if desired.