### PR TITLE
cleanup: initialize vars in the EventLoop constructor in the correct order

### DIFF
--- a/src/mp/proxy.cpp
+++ b/src/mp/proxy.cpp
@@ -156,9 +156,9 @@ void Connection::addAsyncCleanup(std::function<void()> fn)
 EventLoop::EventLoop(const char* exe_name, LogFn log_fn, void* context)
     : m_exe_name(exe_name),
       m_io_context(kj::setupAsyncIo()),
+      m_task_set(new kj::TaskSet(m_error_handler)),
       m_log_fn(std::move(log_fn)),
-      m_context(context),
-      m_task_set(new kj::TaskSet(m_error_handler))
+      m_context(context)
 {
     int fds[2];
     KJ_SYSCALL(socketpair(AF_UNIX, SOCK_STREAM, 0, fds));


### PR DESCRIPTION
This legitimate warning pops up when built with clang 20 and Core's flags:

`warning: field 'm_context' will be initialized after field 'm_task_set' [-Wreorder-ctor]`

It looks like there are no dependency issues here and the reordering is safe, but please let me know if I'm wrong.