### PR TITLE
CTest: Module must be included at the top level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(Libmultiprocess_EXTERNAL_MPGEN "" CACHE FILEPATH "If specified, should be fu
 
 include("cmake/compat_config.cmake")
 include("cmake/pthread_checks.cmake")
+include(CTest)
 include(GNUInstallDirs)
 
 # Set convenience variables for subdirectories.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,8 +2,6 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-include(CTest)
-
 # Custom test targets for convenience, based on
 # https://gitlab.kitware.com/cmake/community/-/wikis/doc/tutorials/EmulateMakeCheck.
 #


### PR DESCRIPTION
In order to be able to run `ctest` from the top level build directory, it is necessary that `enable_testing()` is invoked in the top level CMakeLists.txt file. The `CTest` module invokes `enable_testing()` based on the value of `BUILD_TESTING`.