### PR TITLE
util: fix -Wpessimizing-move warning

### DIFF
--- a/src/mp/util.cpp
+++ b/src/mp/util.cpp
@@ -71,7 +71,7 @@ std::string ThreadName(const char* exe_name)
     buffer << std::this_thread::get_id();
 #endif
 
-    return std::move(buffer.str());
+    return std::move(buffer).str();
 }
 
 std::string LogEscape(const kj::StringTree& string)


### PR DESCRIPTION
/ci_container_base/src/ipc/libmultiprocess/src/mp/util.cpp:74:12: error: moving a temporary object prevents copy elision [-Werror,-Wpessimizing-move]
   74 |     return std::move(buffer.str());
      |            ^
/ci_container_base/src/ipc/libmultiprocess/src/mp/util.cpp:74:12: note: remove std::move call here
   74 |     return std::move(buffer.str());
      |            ^~~~~~~~~~            ~