### PR TITLE
Avoid `-Wundef` compiler warnings

### DIFF
--- a/src/mp/util.cpp
+++ b/src/mp/util.cpp
@@ -19,7 +19,7 @@
 #include <thread>
 #include <unistd.h>
 
-#if __linux__
+#ifdef __linux__
 #include <syscall.h>
 #endif
 
@@ -59,7 +59,7 @@ std::string ThreadName(const char* exe_name)
 
     // Prefer platform specific thread ids over the standard C++11 ones because
     // the former are shorter and are the same as what gdb prints "LWP ...".
-#if __linux__
+#ifdef __linux__
     buffer << syscall(SYS_gettid);
 #elif defined(HAVE_PTHREAD_THREADID_NP)
     uint64_t tid = 0;


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/pull/30975#issuecomment-2633222863:
> On my own macOS 15.3 with Xcode 16.2 machine building fails:
> 
> ```
> git clean -dfx
> cmake -B build -DENABLE_IPC=ON
> cmake --build build
> ...
> /Users/sjors/dev/bitcoin/src/ipc/libmultiprocess/src/mp/util.cpp:22:5: error: '__linux__' is not defined, evaluates to 0 [-Werror,-Wundef]
>    22 | #if __linux__
>       |     ^
> /Users/sjors/dev/bitcoin/src/ipc/libmultiprocess/src/mp/util.cpp:62:5: error: '__linux__' is not defined, evaluates to 0 [-Werror,-Wundef]
>    62 | #if __linux__
>       |     ^
> 2 errors generated.
> ```

