### PR TITLE
Fix `-Wsign-compare` compiler warning

### DIFF
--- a/src/mp/gen.cpp
+++ b/src/mp/gen.cpp
@@ -630,7 +630,7 @@ int main(int argc, char** argv)
     } else {
         throw std::runtime_error(std::string("Failed to open src_prefix prefix directory: ") + argv[1]);
     }
-    for (size_t i = 4; i < argc; ++i) {
+    for (size_t i = 4; i < static_cast<size_t>(argc); ++i) {
         KJ_IF_MAYBE(dir, fs->getRoot().tryOpenSubdir(cwd.evalNative(argv[i]))) {
             import_paths.emplace_back(argv[i]);
             import_dirs.emplace_back(kj::mv(*dir));


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/pull/30975#issuecomment-2634356140:
> ... then found another issue:
> 
> ```
> /home/runner/work/_temp/src/ipc/libmultiprocess/src/mp/gen.cpp:633:26: error: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'int' [-Werror,-Wsign-compare]
>   633 |     for (size_t i = 4; i < argc; ++i) {
>       |                        ~ ^ ~~~~
> 1 error generated.
> ```

This is the only warning when all default Bitcoin Core [flags](https://github.com/bitcoin/bitcoin/blob/94ca99ac51dddbee79d6409ebcc43b1119b0aca9/CMakeLists.txt#L410-L440) are applied.