### PR TITLE
refactor: Avoid using std::format

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <filesystem>
-#include <format>
 #include <fstream>
 #include <future>
 #include <init.capnp.h>
@@ -26,7 +25,7 @@ static auto Spawn(mp::EventLoop& loop, const std::string& process_argv0, const s
         fs::path path = process_argv0;
         path.remove_filename();
         path.append(new_exe_name);
-        return {path.string(), std::format("{:d}", fd)};
+        return {path.string(), std::to_string(fd)};
     });
     return std::make_tuple(mp::ConnectStream<InitInterface>(loop, fd), pid);
 }

--- a/src/mp/util.cpp
+++ b/src/mp/util.cpp
@@ -6,7 +6,6 @@
 #include <mp/util.h>
 
 #include <errno.h>
-#include <format>
 #include <kj/common.h>
 #include <kj/string-tree.h>
 #include <pthread.h>
@@ -86,7 +85,9 @@ std::string LogEscape(const kj::StringTree& string)
             if (c == '\\') {
                 result.append("\\\\");
             } else if (c < 0x20 || c > 0x7e) {
-                result.append(std::format("\\{:02x}", c));
+                char escape[4];
+                snprintf(escape, 4, "\\%02x", c);
+                result.append(escape);
             } else {
                 result.push_back(c);
             }


### PR DESCRIPTION
Partially revert #156 due to lack of compiler support for std::format, as reported https://github.com/chaincodelabs/libmultiprocess/pull/156#issuecomment-2643476222 and https://github.com/bitcoin/bitcoin/pull/31741#issuecomment-2643619428

Technically it means this code is using locale dependent functions again, though I think in practice results will not be locale dependent because these are just integers not floating point numbers being formatted.

This code could be written to use std::to_chars and be more independent, at the cost being slightly more complicated. Could be considered for a followup.