### PR TITLE
Bump minimum required cmake to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.12)
 
 project("Libmultiprocess" CXX)
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)


### PR DESCRIPTION
This project requires C++20. However, according to https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html, the value `20` was only added in cmake 3.12.

Thus, reflect the reality also in the cmake required minimum version.

As a side-effect this also avoids a deprecation message when compiling with cmake 3.31, according to https://cmake.org/cmake/help/latest/release/3.31.html#deprecated-and-removed-features