### PR TITLE
clang-tidy: fix warnings introduced in version 19

### DIFF
--- a/include/mp/proxy-io.h
+++ b/include/mp/proxy-io.h
@@ -172,7 +172,7 @@ public:
     void addClient(std::unique_lock<std::mutex>& lock);
     bool removeClient(std::unique_lock<std::mutex>& lock);
     //! Check if loop should exit.
-    bool done(std::unique_lock<std::mutex>& lock);
+    bool done(std::unique_lock<std::mutex>& lock) const;
 
     Logger log()
     {

--- a/src/mp/gen.cpp
+++ b/src/mp/gen.cpp
@@ -215,7 +215,7 @@ static void Generate(kj::StringPtr src_prefix,
     cpp_types << "namespace mp {\n";
 
     std::string guard = output_path;
-    std::transform(guard.begin(), guard.end(), guard.begin(), [](unsigned char c) -> unsigned char {
+    std::ranges::transform(guard, guard.begin(), [](unsigned char c) -> unsigned char {
         if ('0' <= c && c <= '9') return c;
         if ('A' <= c && c <= 'Z') return c;
         if ('a' <= c && c <= 'z') return c - 'a' + 'A';

--- a/src/mp/proxy.cpp
+++ b/src/mp/proxy.cpp
@@ -277,7 +277,7 @@ void EventLoop::startAsyncThread(std::unique_lock<std::mutex>& lock)
     }
 }
 
-bool EventLoop::done(std::unique_lock<std::mutex>& lock)
+bool EventLoop::done(std::unique_lock<std::mutex>& lock) const
 {
     assert(m_num_clients >= 0);
     assert(lock.owns_lock());


### PR DESCRIPTION
Should fix #153.