### PR TITLE
 type-function.h: Fix CustomBuildField overload

### DIFF
--- a/include/mp/type-function.h
+++ b/include/mp/type-function.h
@@ -24,7 +24,7 @@ template <typename Value, typename FnR, typename... FnParams, typename Output>
 void CustomBuildField(TypeList<std::function<FnR(FnParams...)>>,
     Priority<1>,
     InvokeContext& invoke_context,
-    Value& value,
+    Value&& value,
     Output&& output)
 {
     if (value) {

--- a/test/mp/test/foo-types.h
+++ b/test/mp/test/foo-types.h
@@ -8,6 +8,7 @@
 #include <mp/proxy-types.h>
 #include <mp/type-context.h>
 #include <mp/type-decay.h>
+#include <mp/type-function.h>
 #include <mp/type-interface.h>
 #include <mp/type-map.h>
 #include <mp/type-message.h>

--- a/test/mp/test/foo.capnp
+++ b/test/mp/test/foo.capnp
@@ -28,6 +28,7 @@ interface FooInterface $Proxy.wrap("mp::test::FooImplementation") {
     passMessage @13 (arg :FooMessage) -> (result :FooMessage);
     passMutable @14 (arg :FooMutable) -> (arg :FooMutable);
     passEnum @15 (arg :Int32) -> (result :Int32);
+    passFn @16 (context :Proxy.Context, fn :FooFn) -> (result :Int32);
 }
 
 interface FooCallback $Proxy.wrap("mp::test::FooCallback") {
@@ -37,6 +38,11 @@ interface FooCallback $Proxy.wrap("mp::test::FooCallback") {
 
 interface ExtendedCallback extends(FooCallback) $Proxy.wrap("mp::test::ExtendedCallback") {
     callExtended @0 (context :Proxy.Context, arg :Int32) -> (result :Int32);
+}
+
+interface FooFn $Proxy.wrap("ProxyCallback<std::function<int()>>") {
+    destroy @0 (context :Proxy.Context) -> ();
+    call @1 (context :Proxy.Context) -> (result :Int32);
 }
 
 struct FooStruct $Proxy.wrap("mp::test::FooStruct") {

--- a/test/mp/test/foo.h
+++ b/test/mp/test/foo.h
@@ -5,6 +5,7 @@
 #ifndef MP_TEST_FOO_H
 #define MP_TEST_FOO_H
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>
@@ -75,6 +76,7 @@ public:
     FooMessage passMessage(FooMessage foo) { foo.message += " call"; return foo; }
     void passMutable(FooMutable& foo) { foo.message += " call"; }
     FooEnum passEnum(FooEnum foo) { return foo; }
+    int passFn(std::function<int()> fn) { return fn(); }
     std::shared_ptr<FooCallback> m_callback;
 };
 

--- a/test/mp/test/test.cpp
+++ b/test/mp/test/test.cpp
@@ -128,6 +128,8 @@ KJ_TEST("Call FooInterface methods")
     foo->passMutable(mut);
     KJ_EXPECT(mut.message == "init build pass call return read");
 
+    KJ_EXPECT(foo->passFn([]{ return 10; }) == 10);
+
     disconnect_client();
     thread.join();
 


### PR DESCRIPTION
Fix `std::function` `CustomBuildField` overload which is incompatible with a recent change in 3a96cdc18f2d1ca202fbc91551f27097fd7ec7f6 from https://github.com/bitcoin-core/libmultiprocess/pull/172 which changed generated IPC client code to pass it an rvalue `std::function` reference instead of an lvalue reference.

Motivation for this change is to avoid a build error in https://github.com/bitcoin/bitcoin/pull/29409, when rebased on top of https://github.com/bitcoin/bitcoin/pull/32641 which includes https://github.com/bitcoin-core/libmultiprocess/pull/172.
