### PR TITLE
ci: Add NetBSD job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,66 @@ on:
   pull_request:
 
 jobs:
+  build-netbsd:
+    runs-on: ubuntu-latest
+    name: build • netbsd ${{ matrix.release }}
+    defaults:
+      run:
+        shell: netbsd {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Test all supported releases.
+        # See https://www.netbsd.org/releases/.
+        include:
+          - release: 9.4
+            capnproto-cppflags: 'CPPFLAGS="-DKJ_NO_EXCEPTIONS=0 -DKJ_USE_KQUEUE=0"'
+          - release: 10.1
+            capnproto-cppflags: 'CPPFLAGS="-DKJ_NO_EXCEPTIONS=0"'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Start NetBSD VM
+        uses: vmactions/netbsd-vm@v1
+        with:
+          release: ${{ matrix.release }}
+          # The installed compiler version must match the CXX variable
+          # defined in `ci/configs/netbsd.bash`.
+          prepare: |
+            pkg_add cmake ninja-build gcc14
+          # capnproto prerequisites.
+          # See the following "Install capnproto" step.
+          run: |
+            set -e
+            pkg_add digest libtool-base mktools pkgconf cwrappers
+            pkg_admin -K /usr/pkg/pkgdb fetch-pkg-vulnerabilities
+            cd /usr
+            cvs -danoncvs@anoncvs.NetBSD.org:/cvsroot checkout -P \
+              pkgsrc/devel/capnproto \
+              pkgsrc/devel/libtool-base \
+              pkgsrc/devel/pkgconf \
+              pkgsrc/devel/zlib \
+              `# gcc15 is referenced here because the pkgsrc framework requires lang/gcc15/version.mk to exist` \
+              `# during the "make install" step below, even though we compile our project with gcc14.` \
+              pkgsrc/lang/gcc15 \
+              pkgsrc/mk \
+              pkgsrc/pkgtools \
+              pkgsrc/security/openssl \
+              pkgsrc/sysutils/install-sh/files
+          sync: 'rsync'
+          copyback: false
+
+      - name: Install capnproto
+        run: |
+          cd /usr/pkgsrc/devel/capnproto/
+          unset PKG_PATH
+          make ${{ matrix.capnproto-cppflags }} install
+
+      - name: Run CI script
+        run: |
+          cd ${{ github.workspace }}
+          CI_CONFIG="ci/configs/netbsd.bash" bash ci/scripts/ci.sh
+
   build-openbsd:
     runs-on: ubuntu-latest
     name: build • openbsd

--- a/ci/configs/netbsd.bash
+++ b/ci/configs/netbsd.bash
@@ -1,0 +1,11 @@
+CI_DESC="CI config for NetBSD"
+CI_DIR=build-netbsd
+export CXXFLAGS="-Werror -Wall -Wextra -Wpedantic -Wno-unused-parameter"
+# Hardcode GCC 14, since default GCC versions installed by NetBSD are older
+# and may not be compatible with libmultiprocess. GCC 14 was chosen because
+# it's the latest compiler available on all versions of NetBSD that we test.
+# Note that the GCC version specified here must match the version specified
+# in pkg_add in ci.yml.
+export CXX="/usr/pkg/gcc14/bin/g++"
+CMAKE_ARGS=(-G Ninja)
+BUILD_ARGS=(-k 0)


### PR DESCRIPTION
The master branch @ 1b8d4a6f1e54b92708bd2ad627ec6d440a1daf3d fails to build on NetBSD.

See: https://github.com/hebasto/libmultiprocess/actions/runs/17175941246/job/48731811650