### PR TITLE
cmake: support default build and test workflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,4 +216,4 @@ add_dependencies(install-lib multiprocess)
 
 # Example and test subdirectories
 add_subdirectory(example EXCLUDE_FROM_ALL)
-add_subdirectory(test EXCLUDE_FROM_ALL)
+add_subdirectory(test)

--- a/ci/scripts/ci.sh
+++ b/ci/scripts/ci.sh
@@ -12,7 +12,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 
 : "${CI_DIR:=build}"
 if ! [ -v BUILD_TARGETS ]; then
-  BUILD_TARGETS=(all tests mpexamples)
+  BUILD_TARGETS=(all mpexamples)
 fi
 
 [ -n "${CI_CLEAN-}" ] && rm -rf "${CI_DIR}"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,23 +2,6 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-# Custom test targets for convenience, based on
-# https://gitlab.kitware.com/cmake/community/-/wikis/doc/tutorials/EmulateMakeCheck.
-#
-# CTest already provides a "make test" target, but it just runs existing tests
-# that were previously built, without building anything itself. Define "make
-# tests" here as a custom target to build all available tests and "make check"
-# as a custom target to build and run them.
-add_custom_target(mptests)
-add_custom_target(mpcheck COMMAND ${CMAKE_CTEST_COMMAND} DEPENDS mptests)
-
-# Only add more convenient tests and check targets if project is being built
-# standalone, to prevent clashes with external projects.
-if (MP_STANDALONE)
-  add_custom_target(tests DEPENDS mptests)
-  add_custom_target(check DEPENDS mpcheck)
-endif()
-
 if(BUILD_TESTING AND TARGET CapnProto::kj-test)
   set_property(SOURCE ${MP_PROXY_HDRS} PROPERTY GENERATED 1)
 
@@ -34,6 +17,5 @@ if(BUILD_TESTING AND TARGET CapnProto::kj-test)
   target_link_libraries(mptest PRIVATE CapnProto::kj-test)
   target_link_libraries(mptest PRIVATE Threads::Threads)
 
-  add_dependencies(mptests mptest)
   add_test(NAME mptest COMMAND mptest)
 endif()


### PR DESCRIPTION
Make sure that the default workflow of `cmake ..; make; make test` does not fail with an error message that no tests are found.

Remove any "convenience" targets that add maintenance burden and require tribal knowledge.