### PR TITLE
ci: Replace nix-shell with equivalent nix develop command

### DIFF
--- a/ci/scripts/run.sh
+++ b/ci/scripts/run.sh
@@ -10,4 +10,4 @@ set -o errexit -o nounset -o pipefail -o xtrace
 
 [ "${CI_CONFIG+x}" ] && source "$CI_CONFIG"
 
-nix-shell --pure --keep CI_CONFIG --keep CI_CLEAN "${NIX_ARGS[@]+"${NIX_ARGS[@]}"}" --run ci/scripts/ci.sh shell.nix
+nix develop --ignore-environment --keep CI_CONFIG --keep CI_CLEAN "${NIX_ARGS[@]+"${NIX_ARGS[@]}"}" -f shell.nix --command ci/scripts/ci.sh


### PR DESCRIPTION
Functionality is the same, this just shows nicer status information when building locally. (For even nicer status information you can install nix-output-monitor and replace "nix develop" with "nom develop")