### PR TITLE
Add versions.md and version.h files describing version branches and tags

### DIFF
--- a/doc/versions.md
+++ b/doc/versions.md
@@ -1,0 +1,46 @@
+# libmultiprocess Versions
+
+Library versions are tracked with simple
+[tags](https://github.com/bitcoin-core/libmultiprocess/tags) and
+[branches](https://github.com/bitcoin-core/libmultiprocess/branches).
+
+Versioning policy is described in the [version.h](../include/mp/version.h)
+include.
+
+## v7
+- Current unstable version in master branch.
+- Intended to be compatible with Bitcoin Core 30.1 and future releases.
+
+## v6.0
+- `EventLoop::addClient` and `EventLoop::removeClient` methods dropped,
+  requiring clients to use new `EventLoopRef` class instead.
+- Compatible with Bitcoin Core 30.0 release.
+
+## v5.0
+- Broke up `proxy-types.h` into `type-*.h` files requiring clients to explicitly
+  include overloads needed for C++ ↔️ Cap'n Proto type conversions.
+- Now requires C++ 20 support.
+- Compatible with Bitcoin Core 29 releases.
+
+## v4.0
+- Added better cmake support, installing cmake package files so clients do not
+  need to use pkgconfig.
+- Compatible with Bitcoin Core 28 releases.
+
+## v3.0
+- Dropped compatibility with Cap'n Proto versions before 0.7.
+- Compatible with Bitcoin Core 27 releases.
+
+## v2.0
+- Changed `PassField` function signature.
+- Now requires C++17 support.
+- Compatible with Bitcoin Core 25 and 26 releases.
+
+## v1.0
+- Dropped hardcoded includes in generated files, now requiring `include` and
+  `includeTypes` annotations.
+- Compatible with Bitcoin Core 22, 23, and 24 releases.
+
+## v0.0
+- Initial version used in a downstream release.
+- Compatible with Bitcoin Core 21 releases.

--- a/include/mp/version.h
+++ b/include/mp/version.h
@@ -1,0 +1,26 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef MP_VERSION_H
+#define MP_VERSION_H
+
+//! Major version number. Should be incremented in the master branch before
+//! changes that introduce major new features or break API compatibility, if
+//! there are clients relying on the previous API. (If an API changes multiple
+//! times and nothing uses the intermediate changes, it is sufficient to
+//! increment this only once before the first change.)
+//!
+//! Each time this is incremented, a new stable branch should be created. E.g.
+//! when this is incremented to 8, a "v7" stable branch should be created
+//! pointing at the prior merge commit. The /doc/versions.md file should also be
+//! updated, noting any significant or incompatible changes made since the
+//! previous version, and backported to the stable branch before it is tagged.
+#define MP_MAJOR_VERSION 7
+
+//! Minor version number. Should be incremented in stable branches after
+//! backporting changes. The /doc/versions.md file in the master and stable
+//! branches should also be updated to list the new minor version.
+#define MP_MINOR_VERSION 0
+
+#endif // MP_VERSION_H

--- a/test/mp/test/test.cpp
+++ b/test/mp/test/test.cpp
@@ -25,6 +25,7 @@
 #include <mp/proxy.capnp.h>
 #include <mp/proxy-io.h>
 #include <mp/util.h>
+#include <mp/version.h>
 #include <optional>
 #include <set>
 #include <stdexcept>
@@ -32,11 +33,18 @@
 #include <string_view>
 #include <system_error>
 #include <thread>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
 namespace mp {
 namespace test {
+
+/** Check version.h header values */
+constexpr auto kMP_MAJOR_VERSION{MP_MAJOR_VERSION};
+constexpr auto kMP_MINOR_VERSION{MP_MINOR_VERSION};
+static_assert(std::is_integral_v<decltype(kMP_MAJOR_VERSION)>, "MP_MAJOR_VERSION must be an integral constant");
+static_assert(std::is_integral_v<decltype(kMP_MINOR_VERSION)>, "MP_MINOR_VERSION must be an integral constant");
 
 /**
  * Test setup class creating a two way connection between a


### PR DESCRIPTION
Having libmultiprocess version numbers should be helpful for:

- Backporting fixes for previous Bitcoin Core releases if we need to do that at some point (https://github.com/bitcoin/bitcoin/issues/33439).
- Letting Bitcoin Core releases describe what libmultiprocess versions they are compatible with (https://github.com/bitcoin/bitcoin/issues/33576)
- Letting code detect what version is used at compile-time or runtime, for logging, feature detection, error reporting, or other purposes.