### PR TITLE
ci: Install binary package `capnproto` on OpenBSD instead of building it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,9 @@ jobs:
         uses: vmactions/openbsd-vm@v1
         with:
           prepare: |
-            pkg_add -v cmake ninja git bash
-          run: |
-            git clone --depth=1 https://codeberg.org/OpenBSD/ports.git /usr/ports
+            pkg_add -v cmake ninja bash capnproto
           sync: 'rsync'
           copyback: false
-
-      - name: Install capnproto
-        run: |
-          cd /usr/ports/devel/capnproto/
-          make install
 
       - name: Run CI script
         run: |


### PR DESCRIPTION
OpenBSD 7.8 now provides a binary package for [`capnproto`](https://www.ports.to/path/devel/capnproto.html).