### PR TITLE
 type-context.h: Extent cancel_mutex lock to prevent theoretical race

### DIFF
--- a/include/mp/type-context.h
+++ b/include/mp/type-context.h
@@ -210,7 +210,7 @@ auto PassField(Priority<1>, TypeList<>, ServerContext& server_context, const Fn&
     // connection is destroyed. (By default Cap'n Proto does not cancel requests
     // on disconnect, since it's possible clients might want to make requests
     // and immediately disconnect without waiting for results, but not want the
-    // the requests to be canceled.)
+    // requests to be canceled.)
     return server.m_context.connection->m_canceler.wrap(kj::mv(result));
 }
 } // namespace mp

--- a/include/mp/util.h
+++ b/include/mp/util.h
@@ -331,7 +331,7 @@ void CancelMonitor::promiseDestroyed(CancelProbe& probe)
     // theory this method could be called when a promise was fulfilled or
     // rejected rather than canceled, but it's safe to assume that's not the
     // case because the CancelMonitor class is meant to be used inside code
-    // fulfilling or rejecting the promise and destroyed before doing these.
+    // fulfilling or rejecting the promise and destroyed before doing so.
     assert(m_probe == &probe);
     m_canceled = true;
     if (m_on_cancel) m_on_cancel();


### PR DESCRIPTION
This is a followup to #240 that fixes a theoretical race condition in that PR pointed out by janb https://github.com/bitcoin/bitcoin/pull/34422#discussion_r2849037119. Details are in the commit message. There is also an additional commit fixing up some documentation added in that PR