### PR TITLE
type-map: Work around LLVM 22 "out of bounds index" error

### DIFF
--- a/include/mp/type-map.h
+++ b/include/mp/type-map.h
@@ -27,6 +27,35 @@ void CustomBuildField(TypeList<std::map<KeyLocalType, ValueLocalType>>,
     }
 }
 
+// Replacement for `m.emplace(piecewise_construct, t1, t2)` to work around a
+// Clang 22 regression triggered by libc++'s std::map piecewise emplace: when
+// the key constructor argument tuple is empty (std::tuple<>), libc++'s internal
+// "try key extraction" SFINAE probe instantiates std::tuple_element<0,
+// std::tuple<>>, which Clang 22 diagnoses as an out-of-bounds pack access ("a
+// parameter pack may not be accessed at an out of bounds index") instead of
+// treating it as substitution failure. See LLVM issue #167709 and the upstream
+// fix in llvm/llvm-project PR #183614.
+// https://github.com/llvm/llvm-project/issues/167709
+// https://github.com/llvm/llvm-project/pull/183614
+template <class Map, class Tuple1, class Tuple2>
+auto EmplacePiecewiseSafe(
+    Map& m,
+    const std::piecewise_construct_t&,
+    Tuple1&& t1,
+    Tuple2&& t2)
+{
+    if constexpr (std::tuple_size_v<std::remove_reference_t<Tuple1>> == 0) {
+        // Avoid tuple<> / tuple<> (LLVM 22 libc++ regression path)
+        return m.emplace(std::piecewise_construct,
+                         std::forward_as_tuple(typename Map::key_type{}),
+                         std::forward<Tuple2>(t2));
+    } else {
+        return m.emplace(std::piecewise_construct,
+                         std::forward<Tuple1>(t1),
+                         std::forward<Tuple2>(t2));
+    }
+}
+
 template <typename KeyLocalType, typename ValueLocalType, typename Input, typename ReadDest>
 decltype(auto) CustomReadField(TypeList<std::map<KeyLocalType, ValueLocalType>>,
     Priority<1>,
@@ -42,7 +71,7 @@ decltype(auto) CustomReadField(TypeList<std::map<KeyLocalType, ValueLocalType>>,
                 Make<ValueField>(item),
                 ReadDestEmplace(
                     TypeList<std::pair<const KeyLocalType, ValueLocalType>>(), [&](auto&&... args) -> auto& {
-                        return *value.emplace(std::forward<decltype(args)>(args)...).first;
+                        return *EmplacePiecewiseSafe(value, std::forward<decltype(args)>(args)...).first;
                     }));
         }
     });


### PR DESCRIPTION
This workaround is needed to fix "parameter pack may not be accessed at an out of bounds index" compile errors in
https://github.com/bitcoin/bitcoin/pull/29409 due in sanitizer jobs due to https://github.com/bitcoin/bitcoin/pull/34660 which updates sanitizers to use LLVM 22 instead of LLVM 21:

https://github.com/bitcoin/bitcoin/actions/runs/22501264518/job/65188721708?pr=29409 https://github.com/bitcoin/bitcoin/actions/runs/22501264518/job/65188721733?pr=29409

```c++
/cxx_build/include/c++/v1/__fwd/tuple.h:40:52: error: a parameter pack may not be accessed at an out of bounds index
   40 |   using type _LIBCPP_NODEBUG = __type_pack_element<_Ip, _Tp...>;
      |                                                    ^
/cxx_build/include/c++/v1/__utility/try_key_extraction.h:82:67: note: in instantiation of template class 'std::tuple_element<0, std::tuple<>>' requested here
   82 |                             is_same<__remove_const_ref_t<typename tuple_element<0, _Tuple1>::type>, _KeyT>::value,
      |                                                                   ^
```

The upstream LLVM bug is https://github.com/llvm/llvm-project/issues/167709 and fix is https://github.com/llvm/llvm-project/pull/183614