### PR TITLE
Improved CustomBuildField for std::optional in IPC/libmultiprocess

### DIFF
--- a/include/mp/type-optional.h
+++ b/include/mp/type-optional.h
@@ -17,8 +17,7 @@ void CustomBuildField(TypeList<std::optional<LocalType>>,
 {
     if (value) {
         output.setHas();
-        // FIXME: should std::move value if destvalue is rref?
-        BuildField(TypeList<LocalType>(), invoke_context, output, *value);
+        BuildField(TypeList<LocalType>(), invoke_context, output, *std::forward<Value>(value));
     }
 }
 


### PR DESCRIPTION
The function now uses std::forward(value) when building the field, so rvalues are forwarded correctly instead of always being treated as lvalues. This resolves the existing FIXME in that code path.

Details
Previously, the implementation forced every optional value to be accessed as an lvalue, which meant rvalues were unnecessarily copied. By applying perfect forwarding, the function now preserves the value category and allows moves where appropriate. The FIXME comment was removed since the intended behavior is now implemented
