### PR TITLE
Add nonunix platform support

### DIFF
--- a/.github/workflows/bitcoin-core-ci.yml
+++ b/.github/workflows/bitcoin-core-ci.yml
@@ -18,6 +18,8 @@ concurrency:
 
 env:
   BITCOIN_REPO: bitcoin/bitcoin
+  # Temporary: use PR #35084 until it merges; revert to refs/heads/master after
+  BITCOIN_CORE_REF: refs/pull/35084/merge
   LLVM_VERSION: 22
   LIBCXX_DIR: /tmp/libcxx-build/
 
@@ -78,6 +80,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ env.BITCOIN_REPO }}
+          ref: ${{ env.BITCOIN_CORE_REF }}
           fetch-depth: 1
 
       - name: Checkout libmultiprocess
@@ -194,6 +197,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ env.BITCOIN_REPO }}
+          ref: ${{ env.BITCOIN_CORE_REF }}
           fetch-depth: 1
 
       - name: Checkout libmultiprocess

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 include("cmake/compat_find.cmake")
 
 find_package(Threads REQUIRED)
-find_package(CapnProto 0.7 QUIET NO_MODULE)
+find_package(CapnProto 0.9 QUIET NO_MODULE)
  if(NOT CapnProto_FOUND)
    message(FATAL_ERROR
      "Cap'n Proto is required but was not found.\n"

--- a/ci/configs/olddeps.bash
+++ b/ci/configs/olddeps.bash
@@ -1,5 +1,5 @@
 CI_DESC="CI job using old Cap'n Proto and cmake versions"
 CI_DIR=build-olddeps
 export CXXFLAGS="-Werror -Wall -Wextra -Wpedantic -Wno-unused-parameter -Wno-error=array-bounds"
-NIX_ARGS=(--argstr capnprotoVersion "0.7.1" --argstr cmakeVersion "3.12.4")
+NIX_ARGS=(--argstr capnprotoVersion "0.9.2" --argstr cmakeVersion "3.12.4")
 BUILD_ARGS=(-k)

--- a/doc/design.md
+++ b/doc/design.md
@@ -120,7 +120,7 @@ sequenceDiagram
     participant PMT as ProxyMethodTraits
     participant Impl as Actual C++ Method
 
-    serverInvoke->>SF1: SF1::invoke 
+    serverInvoke->>SF1: SF1::invoke
     SF1->>SF2: SF2::invoke
     SF2->>SR: SR::invoke
     SR->>SC: SC::invoke
@@ -167,7 +167,7 @@ Thread mapping enables each client thread to have a dedicated server thread proc
 Thread mapping is initialized by defining an interface method with a `ThreadMap` parameter and/or response. The example below adds `ThreadMap` to the `construct` method because libmultiprocess calls the `construct` method automatically.
 
 ```capnp
-interface InitInterface $Proxy.wrap("Init") { 
+interface InitInterface $Proxy.wrap("Init") {
     construct @0 (threadMap: Proxy.ThreadMap) -> (threadMap :Proxy.ThreadMap);
 }
 ```

--- a/doc/versions.md
+++ b/doc/versions.md
@@ -7,8 +7,14 @@ Library versions are tracked with simple
 Versioning policy is described in the [version.h](../include/mp/version.h)
 include.
 
-## v13
+## v14
+- Adds support for nonunix platforms, making API changes that are not backwards compatible ([#274](https://github.com/bitcoin-core/libmultiprocess/pull/274)).
 - Current unstable version.
+
+## [v13.0](https://github.com/bitcoin-core/libmultiprocess/commits/v13.0)
+- Fixes a `memcpy` ubsan warning by using `std::ranges::copy` ([#305](https://github.com/bitcoin-core/libmultiprocess/pull/305)).
+- Misc: map serialization round-trip test coverage ([#297](https://github.com/bitcoin-core/libmultiprocess/pull/297)) and version bump ([#306](https://github.com/bitcoin-core/libmultiprocess/pull/306)).
+- Used in Bitcoin Core 32.x and newer releases with [#35720](https://github.com/bitcoin/bitcoin/pull/35720).
 
 ## [v12.0](https://github.com/bitcoin-core/libmultiprocess/commits/v12.0)
 - Adds an optional `max_connections` parameter to `ListenConnections` ([#269](https://github.com/bitcoin-core/libmultiprocess/pull/269)).
@@ -24,7 +30,7 @@ include.
 - Fixes a rare mptest hang on musl builds caused by a lost wakeup bug in `Waiter` ([#295](https://github.com/bitcoin-core/libmultiprocess/pull/295)).
 - Fixes a race condition in a log print detected by TSan ([#286](https://github.com/bitcoin-core/libmultiprocess/pull/286)).
 - Build improvements: makes `target_capnp_sources` work correctly when libmultiprocess is used as a CMake subproject ([#289](https://github.com/bitcoin-core/libmultiprocess/pull/289)), adds `mp_headers` target for better lint tool support ([#291](https://github.com/bitcoin-core/libmultiprocess/pull/291)), and fixes compatibility with recent Nix and CMake 4.0 ([#238](https://github.com/bitcoin-core/libmultiprocess/pull/238)).
-- Test, CI, documentation, and minor code improvements: design document corrections ([#278](https://github.com/bitcoin-core/libmultiprocess/pull/278)), field constant comments ([#279](https://github.com/bitcoin-core/libmultiprocess/pull/279)), clang-tidy fix ([#292](https://github.com/bitcoin-core/libmultiprocess/pull/292)), new smoke test for double-precision float values ([#294](https://github.com/bitcoin-core/libmultiprocess/pull/294)), new test for recursive async IPC calls ([#301](https://github.com/bitcoin-core/libmultiprocess/pull/301)), removal of libevent from Core CI builds ([#299](https://github.com/bitcoin-core/libmultiprocess/pull/299)), and rename of `EventLoop::m_num_clients` to `m_num_refs` ([#302](https://github.com/bitcoin-core/libmultiprocess/pull/302)).
+- Test, CI, documentation, and minor code improvements: design document corrections ([#278](https://github.com/bitcoin-core/libmultiprocess/pull/278)), field constant comments ([#279](https://github.com/bitcoin-core/libmultiprocess/pull/279)), clang-tidy fix ([#292](https://github.com/bitcoin-core/libmultiprocess/pull/292)), new smoke test for double-precision float values ([#294](https://github.com/bitcoin-core/libmultiprocess/pull/294)), new test for recursive async IPC calls ([#301](https://github.com/bitcoin-core/libmultiprocess/pull/301)), removal of libevent from Core CI builds ([#299](https://github.com/bitcoin-core/libmultiprocess/pull/299)), rename of `EventLoop::m_num_clients` to `m_num_refs` ([#302](https://github.com/bitcoin-core/libmultiprocess/pull/302)), and version bump ([#270](https://github.com/bitcoin-core/libmultiprocess/pull/270)).
 - Used in Bitcoin Core 32.x and newer releases with [#35661](https://github.com/bitcoin/bitcoin/pull/35661).
 
 ## [v10.0](https://github.com/bitcoin-core/libmultiprocess/commits/v10.0)

--- a/example/calculator.cpp
+++ b/example/calculator.cpp
@@ -6,8 +6,7 @@
 #include <init.capnp.h>
 #include <init.capnp.proxy.h> // NOLINT(misc-include-cleaner) // IWYU pragma: keep
 
-#include <charconv>
-#include <cstring>
+#include <cstring> // IWYU pragma: keep
 #include <fstream>
 #include <functional>
 #include <iostream>
@@ -16,9 +15,9 @@
 #include <kj/memory.h>
 #include <memory>
 #include <mp/proxy-io.h>
+#include <mp/util.h>
 #include <stdexcept>
 #include <string>
-#include <system_error>
 #include <utility>
 
 class CalculatorImpl : public Calculator
@@ -51,14 +50,10 @@ int main(int argc, char** argv)
         std::cout << "Usage: mpcalculator <fd>\n";
         return 1;
     }
-    mp::SocketId fd;
-    if (std::from_chars(argv[1], argv[1] + strlen(argv[1]), fd).ec != std::errc{}) {
-        std::cerr << argv[1] << " is not a number or is larger than an int\n";
-        return 1;
-    }
+    mp::SocketId socket{mp::StartSpawned(argv[1])};
     mp::EventLoop loop("mpcalculator", LogPrint);
     std::unique_ptr<Init> init = std::make_unique<InitImpl>();
-    mp::ServeStream<InitInterface>(loop, fd, *init);
+    mp::ServeStream<InitInterface>(loop, socket, *init);
     loop.loop();
     return 0;
 }

--- a/example/calculator.cpp
+++ b/example/calculator.cpp
@@ -51,7 +51,7 @@ int main(int argc, char** argv)
         std::cout << "Usage: mpcalculator <fd>\n";
         return 1;
     }
-    int fd;
+    mp::SocketId fd;
     if (std::from_chars(argv[1], argv[1] + strlen(argv[1]), fd).ec != std::errc{}) {
         std::cerr << argv[1] << " is not a number or is larger than an int\n";
         return 1;

--- a/example/calculator.cpp
+++ b/example/calculator.cpp
@@ -53,7 +53,7 @@ int main(int argc, char** argv)
     mp::SocketId socket{mp::StartSpawned(argv[1])};
     mp::EventLoop loop("mpcalculator", LogPrint);
     std::unique_ptr<Init> init = std::make_unique<InitImpl>();
-    mp::ServeStream<InitInterface>(loop, socket, *init);
+    mp::ServeStream<InitInterface>(loop, mp::MakeStream(loop, socket), *init);
     loop.loop();
     return 0;
 }

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -25,7 +25,7 @@ namespace fs = std::filesystem;
 
 static auto Spawn(mp::EventLoop& loop, const std::string& process_argv0, const std::string& new_exe_name)
 {
-    int pid;
+    mp::ProcessId pid;
     const int fd = mp::SpawnProcess(pid, [&](int fd) -> std::vector<std::string> {
         fs::path path = process_argv0;
         path.remove_filename();

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -26,7 +26,7 @@ namespace fs = std::filesystem;
 static auto Spawn(mp::EventLoop& loop, const std::string& process_argv0, const std::string& new_exe_name)
 {
     mp::ProcessId pid;
-    const int fd = mp::SpawnProcess(pid, [&](int fd) -> std::vector<std::string> {
+    const mp::SocketId fd = mp::SpawnProcess(pid, [&](mp::SocketId fd) -> std::vector<std::string> {
         fs::path path = process_argv0;
         path.remove_filename();
         path.append(new_exe_name);

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -19,20 +19,20 @@
 #include <string>
 #include <thread>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 namespace fs = std::filesystem;
 
 static auto Spawn(mp::EventLoop& loop, const std::string& process_argv0, const std::string& new_exe_name)
 {
-    mp::ProcessId pid;
-    const mp::SocketId fd = mp::SpawnProcess(pid, [&](mp::SocketId fd) -> std::vector<std::string> {
+    const auto [pid, socket] = mp::SpawnProcess([&](mp::SpawnConnectInfo info) -> std::vector<std::string> {
         fs::path path = process_argv0;
         path.remove_filename();
         path.append(new_exe_name);
-        return {path.string(), std::to_string(fd)};
+        return {path.string(), std::move(info)};
     });
-    return std::make_tuple(mp::ConnectStream<InitInterface>(loop, fd), pid);
+    return std::make_tuple(mp::ConnectStream<InitInterface>(loop, socket), pid);
 }
 
 static void LogPrint(mp::LogMessage log_data)

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -32,7 +32,7 @@ static auto Spawn(mp::EventLoop& loop, const std::string& process_argv0, const s
         path.append(new_exe_name);
         return {path.string(), std::move(info)};
     });
-    return std::make_tuple(mp::ConnectStream<InitInterface>(loop, socket), pid);
+    return std::make_tuple(mp::ConnectStream<InitInterface>(loop, mp::MakeStream(loop, socket)), pid);
 }
 
 static void LogPrint(mp::LogMessage log_data)

--- a/example/printer.cpp
+++ b/example/printer.cpp
@@ -7,8 +7,7 @@
 #include <init.capnp.h>
 #include <init.capnp.proxy.h> // NOLINT(misc-include-cleaner) // IWYU pragma: keep
 
-#include <charconv>
-#include <cstring>
+#include <cstring> // IWYU pragma: keep
 #include <fstream>
 #include <iostream>
 #include <kj/async.h>
@@ -16,9 +15,9 @@
 #include <kj/memory.h>
 #include <memory>
 #include <mp/proxy-io.h>
+#include <mp/util.h>
 #include <stdexcept>
 #include <string>
-#include <system_error>
 
 class PrinterImpl : public Printer
 {
@@ -44,14 +43,10 @@ int main(int argc, char** argv)
         std::cout << "Usage: mpprinter <fd>\n";
         return 1;
     }
-    mp::SocketId fd;
-    if (std::from_chars(argv[1], argv[1] + strlen(argv[1]), fd).ec != std::errc{}) {
-        std::cerr << argv[1] << " is not a number or is larger than an int\n";
-        return 1;
-    }
+    mp::SocketId socket{mp::StartSpawned(argv[1])};
     mp::EventLoop loop("mpprinter", LogPrint);
     std::unique_ptr<Init> init = std::make_unique<InitImpl>();
-    mp::ServeStream<InitInterface>(loop, fd, *init);
+    mp::ServeStream<InitInterface>(loop, socket, *init);
     loop.loop();
     return 0;
 }

--- a/example/printer.cpp
+++ b/example/printer.cpp
@@ -44,7 +44,7 @@ int main(int argc, char** argv)
         std::cout << "Usage: mpprinter <fd>\n";
         return 1;
     }
-    int fd;
+    mp::SocketId fd;
     if (std::from_chars(argv[1], argv[1] + strlen(argv[1]), fd).ec != std::errc{}) {
         std::cerr << argv[1] << " is not a number or is larger than an int\n";
         return 1;

--- a/example/printer.cpp
+++ b/example/printer.cpp
@@ -46,7 +46,7 @@ int main(int argc, char** argv)
     mp::SocketId socket{mp::StartSpawned(argv[1])};
     mp::EventLoop loop("mpprinter", LogPrint);
     std::unique_ptr<Init> init = std::make_unique<InitImpl>();
-    mp::ServeStream<InitInterface>(loop, socket, *init);
+    mp::ServeStream<InitInterface>(loop, mp::MakeStream(loop, socket), *init);
     loop.loop();
     return 0;
 }

--- a/include/mp/proxy-io.h
+++ b/include/mp/proxy-io.h
@@ -456,7 +456,7 @@ public:
     //! Capability::Client handles owned by ProxyClient objects), then schedules
     //! asynchronous cleanup functions to run in a worker thread (to run
     //! destructors of m_impl instances owned by ProxyServer objects).
-    ~Connection();
+    ~Connection() noexcept(false);
 
     //! Register synchronous cleanup function to run on event loop thread (with
     //! access to capnp thread local variables) when disconnect() is called.

--- a/include/mp/proxy-io.h
+++ b/include/mp/proxy-io.h
@@ -18,6 +18,7 @@
 #include <cstdlib>
 #include <functional>
 #include <kj/function.h>
+#include <kj/io.h>
 #include <map>
 #include <memory>
 #include <optional>
@@ -311,11 +312,12 @@ public:
     //! Callback functions to run on async thread.
     std::optional<CleanupList> m_async_fns MP_GUARDED_BY(m_mutex);
 
-    //! Pipe read handle used to wake up the event loop thread.
-    SocketId m_wait_fd = SocketError;
+    //! Socket pair used to post and wait for wakeups to the event loop thread.
+    kj::Own<kj::AsyncIoStream> m_wait_stream;
+    kj::Own<kj::AsyncIoStream> m_post_stream;
 
-    //! Pipe write handle used to wake up the event loop thread.
-    SocketId m_post_fd = SocketError;
+    //! Synchronous writer used to write to m_post_stream.
+    kj::Own<kj::OutputStream> m_post_writer;
 
     //! Number of EventLoopRef instances referencing this event loop. This is a
     //! sum of the number of client and server objects (Connection, ProxyClient,

--- a/include/mp/proxy-io.h
+++ b/include/mp/proxy-io.h
@@ -312,10 +312,10 @@ public:
     std::optional<CleanupList> m_async_fns MP_GUARDED_BY(m_mutex);
 
     //! Pipe read handle used to wake up the event loop thread.
-    int m_wait_fd = -1;
+    SocketId m_wait_fd = SocketError;
 
     //! Pipe write handle used to wake up the event loop thread.
-    int m_post_fd = -1;
+    SocketId m_post_fd = SocketError;
 
     //! Number of EventLoopRef instances referencing this event loop. This is a
     //! sum of the number of client and server objects (Connection, ProxyClient,
@@ -917,10 +917,10 @@ void ServeStream(EventLoop& loop, int fd, InitImpl& init)
         [] {});
 }
 
-//! Given listening socket file descriptor and an init object, handle incoming
+//! Given listening socket identifier and an init object, handle incoming
 //! connections and requests by calling methods on the Init object.
 template <typename InitInterface, typename InitImpl>
-void ListenConnections(EventLoop& loop, int fd, InitImpl& init, std::optional<size_t> max_connections = std::nullopt)
+void ListenConnections(EventLoop& loop, SocketId fd, InitImpl& init, std::optional<size_t> max_connections = std::nullopt)
 {
     loop.sync([&]() {
         auto listener{std::make_shared<Listener>(

--- a/include/mp/proxy-io.h
+++ b/include/mp/proxy-io.h
@@ -214,6 +214,9 @@ private:
 
 std::string LongThreadName(const char* exe_name);
 
+//! Wrap a socket file descriptor as an async stream, taking ownership of the fd.
+Stream MakeStream(EventLoop&loop, SocketId socket);
+
 //! Event loop implementation.
 //!
 //! Cap'n Proto threading model is very simple: all I/O operations are
@@ -826,17 +829,15 @@ kj::Promise<T> ProxyServer<Thread>::post(Fn&& fn)
     return ret;
 }
 
-//! Given stream file descriptor, make a new ProxyClient object to send requests
-//! over the stream. Also create a new Connection object embedded in the
-//! client that is freed when the client is closed.
+//! Given a stream, make a new ProxyClient object to send requests over it.
+//! Also create a new Connection object embedded in the client that is freed
+//! when the client is closed.
 template <typename InitInterface>
-std::unique_ptr<ProxyClient<InitInterface>> ConnectStream(EventLoop& loop, int fd)
+std::unique_ptr<ProxyClient<InitInterface>> ConnectStream(EventLoop& loop, Stream stream)
 {
     typename InitInterface::Client init_client(nullptr);
     std::unique_ptr<Connection> connection;
     loop.sync([&] {
-        auto stream =
-            loop.m_io_context.lowLevelProvider->wrapSocketFd(fd, kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP);
         connection = std::make_unique<Connection>(loop, kj::mv(stream));
         init_client = connection->m_rpc_system->bootstrap(ServerVatId().vat_id).castAs<InitInterface>();
         Connection* connection_ptr = connection.get();
@@ -907,16 +908,12 @@ void _Listen(const std::shared_ptr<Listener>& listener, EventLoop& loop, InitImp
         }));
 }
 
-//! Given stream file descriptor and an init object, handle requests on the
-//! stream by calling methods on the Init object.
+//! Given a stream and an init object, handle requests on the stream by calling
+//! methods on the Init object.
 template <typename InitInterface, typename InitImpl>
-void ServeStream(EventLoop& loop, int fd, InitImpl& init)
+void ServeStream(EventLoop& loop, Stream stream, InitImpl& init)
 {
-    _Serve<InitInterface>(
-        loop,
-        loop.m_io_context.lowLevelProvider->wrapSocketFd(fd, kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP),
-        init,
-        [] {});
+    _Serve<InitInterface>(loop, kj::mv(stream), init, [] {});
 }
 
 //! Given listening socket identifier and an init object, handle incoming

--- a/include/mp/proxy.h
+++ b/include/mp/proxy.h
@@ -315,21 +315,21 @@ template <typename Field, int flags>
 struct Accessor : public Field
 {
     //! Field is present from the Cap'n Proto Params struct (client -> server).
-    static const bool in = flags & FIELD_IN;
+    static constexpr bool in = (flags & FIELD_IN) != 0;
     //! Field is present from the Cap'n Proto Results struct (server -> client).
-    static const bool out = flags & FIELD_OUT;
+    static constexpr bool out = (flags & FIELD_OUT) != 0;
     //! Field has a companion has{Name} boolean field in the Cap'n Proto struct.
     //! This is used to represent optional primitive values (e.g. C++
     //! std::optional<int>) because Cap'n Proto doesn't allow primitive fields to
     //! be unset.
-    static const bool optional = flags & FIELD_OPTIONAL;
+    static constexpr bool optional = (flags & FIELD_OPTIONAL) != 0;
     //! Results field has a companion want{Name} boolean field in the Params
     //! struct. Used for optional output parameters (e.g. C++ int*) and set to
     //! true if the caller passed a non-null pointer and wants the result.
-    static const bool requested = flags & FIELD_REQUESTED;
+    static constexpr bool requested = (flags & FIELD_REQUESTED) != 0;
     //! Field is a Cap'n Proto pointer type (struct, list, text, data,
     //! interface) as opposed to a primitive type (bool, int, float, enum).
-    static const bool boxed = flags & FIELD_BOXED;
+    static constexpr bool boxed = (flags & FIELD_BOXED) != 0;
 };
 
 //! Wrapper around std::function for passing std::function objects between client and servers.

--- a/include/mp/type-context.h
+++ b/include/mp/type-context.h
@@ -12,11 +12,11 @@
 
 namespace mp {
 template <typename Output>
+    requires FieldTypeIs<Output, Context::Builder>
 void CustomBuildField(TypeList<>,
     Priority<1>,
     ClientInvokeContext& invoke_context,
-    Output&& output,
-    typename std::enable_if<std::is_same<decltype(output.get()), Context::Builder>::value>::type* enable = nullptr)
+    Output&& output)
 {
     auto& connection = invoke_context.connection;
     auto& thread_context = invoke_context.thread_context;

--- a/include/mp/type-interface.h
+++ b/include/mp/type-interface.h
@@ -21,12 +21,12 @@ kj::Own<typename Interface::Server> CustomMakeProxyServer(InvokeContext& context
 }
 
 template <typename Impl, typename Value, typename Output>
+    requires InterfaceField<Output>
 void CustomBuildField(TypeList<std::unique_ptr<Impl>>,
     Priority<1>,
     InvokeContext& invoke_context,
     Value&& value,
-    Output&& output,
-    typename Decay<decltype(output.get())>::Calls* enable = nullptr)
+    Output&& output)
 {
     if (value) {
         using Interface = typename decltype(output.get())::Calls;
@@ -35,12 +35,12 @@ void CustomBuildField(TypeList<std::unique_ptr<Impl>>,
 }
 
 template <typename Impl, typename Value, typename Output>
+    requires InterfaceField<Output>
 void CustomBuildField(TypeList<std::shared_ptr<Impl>>,
     Priority<2>,
     InvokeContext& invoke_context,
     Value&& value,
-    Output&& output,
-    typename Decay<decltype(output.get())>::Calls* enable = nullptr)
+    Output&& output)
 {
     if (value) {
         using Interface = typename decltype(output.get())::Calls;
@@ -49,12 +49,12 @@ void CustomBuildField(TypeList<std::shared_ptr<Impl>>,
 }
 
 template <typename Impl, typename Output>
+    requires InterfaceField<Output>
 void CustomBuildField(TypeList<Impl&>,
     Priority<1>,
     InvokeContext& invoke_context,
     Impl& value,
-    Output&& output,
-    typename decltype(output.get())::Calls* enable = nullptr)
+    Output&& output)
 {
     // Disable deleter so proxy server object doesn't attempt to delete the
     // wrapped implementation when the proxy client is destroyed or
@@ -77,12 +77,12 @@ std::unique_ptr<Impl> CustomMakeProxyClient(InvokeContext& context, typename Int
 }
 
 template <typename LocalType, typename Input, typename ReadDest>
+    requires InterfaceField<Input>
 decltype(auto) CustomReadField(TypeList<std::unique_ptr<LocalType>>,
     Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
-    ReadDest&& read_dest,
-    typename Decay<decltype(input.get())>::Calls* enable = nullptr)
+    ReadDest&& read_dest)
 {
     using Interface = typename Decay<decltype(input.get())>::Calls;
     if (CustomHasField(TypeList<LocalType>(), invoke_context, input)) {
@@ -93,12 +93,12 @@ decltype(auto) CustomReadField(TypeList<std::unique_ptr<LocalType>>,
 }
 
 template <typename LocalType, typename Input, typename ReadDest>
+    requires InterfaceField<Input>
 decltype(auto) CustomReadField(TypeList<std::shared_ptr<LocalType>>,
     Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
-    ReadDest&& read_dest,
-    typename Decay<decltype(input.get())>::Calls* enable = nullptr)
+    ReadDest&& read_dest)
 {
     using Interface = typename Decay<decltype(input.get())>::Calls;
     if (CustomHasField(TypeList<LocalType>(), invoke_context, input)) {

--- a/include/mp/type-number.h
+++ b/include/mp/type-number.h
@@ -9,10 +9,10 @@
 
 namespace mp {
 template <typename LocalType, typename Value>
+    requires std::is_enum_v<Value>
 LocalType BuildPrimitive(InvokeContext& invoke_context,
     const Value& value,
-    TypeList<LocalType>,
-    typename std::enable_if<std::is_enum<Value>::value>::type* enable = nullptr)
+    TypeList<LocalType>)
 {
     using E = std::make_unsigned_t<std::underlying_type_t<Value>>;
     using T = std::make_unsigned_t<LocalType>;
@@ -21,10 +21,10 @@ LocalType BuildPrimitive(InvokeContext& invoke_context,
 }
 
 template <typename LocalType, typename Value>
+    requires std::is_integral_v<Value>
 LocalType BuildPrimitive(InvokeContext& invoke_context,
     const Value& value,
-    TypeList<LocalType>,
-    typename std::enable_if<std::is_integral<Value>::value, int>::type* enable = nullptr)
+    TypeList<LocalType>)
 {
     static_assert(
         std::numeric_limits<LocalType>::lowest() <= std::numeric_limits<Value>::lowest(), "mismatched integral types");
@@ -34,10 +34,10 @@ LocalType BuildPrimitive(InvokeContext& invoke_context,
 }
 
 template <typename LocalType, typename Value>
+    requires std::is_floating_point_v<Value>
 LocalType BuildPrimitive(InvokeContext& invoke_context,
     const Value& value,
-    TypeList<LocalType>,
-    typename std::enable_if<std::is_floating_point<Value>::value>::type* enable = nullptr)
+    TypeList<LocalType>)
 {
     static_assert(std::is_same<Value, LocalType>::value,
         "mismatched floating point types. please fix message.capnp type declaration to match wrapped interface");
@@ -45,12 +45,12 @@ LocalType BuildPrimitive(InvokeContext& invoke_context,
 }
 
 template <typename LocalType, typename Input, typename ReadDest>
+    requires std::is_enum_v<LocalType>
 decltype(auto) CustomReadField(TypeList<LocalType>,
     Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
-    ReadDest&& read_dest,
-    typename std::enable_if<std::is_enum<LocalType>::value>::type* enable = nullptr)
+    ReadDest&& read_dest)
 {
     // Disable clang-tidy out-of-range enum value check which triggers when
     // using an enum type that does not have a 0 value. The check correctly
@@ -62,12 +62,12 @@ decltype(auto) CustomReadField(TypeList<LocalType>,
 }
 
 template <typename LocalType, typename Input, typename ReadDest>
+    requires std::is_integral_v<LocalType>
 decltype(auto) CustomReadField(TypeList<LocalType>,
     Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
-    ReadDest&& read_dest,
-    typename std::enable_if<std::is_integral<LocalType>::value>::type* enable = nullptr)
+    ReadDest&& read_dest)
 {
     auto value = input.get();
     if (value < std::numeric_limits<LocalType>::min() || value > std::numeric_limits<LocalType>::max()) {
@@ -77,12 +77,12 @@ decltype(auto) CustomReadField(TypeList<LocalType>,
 }
 
 template <typename LocalType, typename Input, typename ReadDest>
+    requires std::is_floating_point_v<LocalType>
 decltype(auto) CustomReadField(TypeList<LocalType>,
     Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
-    ReadDest&& read_dest,
-    typename std::enable_if<std::is_floating_point<LocalType>::value>::type* enable = nullptr)
+    ReadDest&& read_dest)
 {
     auto value = input.get();
     static_assert(std::is_same<LocalType, decltype(value)>::value, "floating point type mismatch");

--- a/include/mp/type-struct.h
+++ b/include/mp/type-struct.h
@@ -9,11 +9,11 @@
 
 namespace mp {
 template <size_t index, typename LocalType, typename Value, typename Output>
+    requires (index < ProxyType<LocalType>::fields)
 void BuildOne(TypeList<LocalType> param,
     InvokeContext& invoke_context,
     Output&& output,
-    Value&& value,
-    typename std::enable_if < index<ProxyType<LocalType>::fields>::type * enable = nullptr)
+    Value&& value)
 {
     using Index = std::integral_constant<size_t, index>;
     using Struct = typename ProxyType<LocalType>::Struct;
@@ -25,31 +25,31 @@ void BuildOne(TypeList<LocalType> param,
 }
 
 template <size_t index, typename LocalType, typename Value, typename Output>
+    requires (index == ProxyType<LocalType>::fields)
 void BuildOne(TypeList<LocalType> param,
     InvokeContext& invoke_context,
     Output&& output,
-    Value&& value,
-    typename std::enable_if<index == ProxyType<LocalType>::fields>::type* enable = nullptr)
+    Value&& value)
 {
 }
 
 template <typename LocalType, typename Value, typename Output>
+    requires requires { typename ProxyType<LocalType>::Struct; }
 void CustomBuildField(TypeList<LocalType> local_type,
     Priority<1>,
     InvokeContext& invoke_context,
     Value&& value,
-    Output&& output,
-    typename ProxyType<LocalType>::Struct* enable = nullptr)
+    Output&& output)
 {
     BuildOne<0>(local_type, invoke_context, output.init(), value);
 }
 
 template <size_t index, typename LocalType, typename Input, typename Value>
+    requires (index != ProxyType<LocalType>::fields)
 void ReadOne(TypeList<LocalType> param,
     InvokeContext& invoke_context,
     Input&& input,
-    Value&& value,
-    typename std::enable_if<index != ProxyType<LocalType>::fields>::type* enable = nullptr)
+    Value&& value)
 {
     using Index = std::integral_constant<size_t, index>;
     using Struct = typename ProxyType<LocalType>::Struct;
@@ -62,21 +62,21 @@ void ReadOne(TypeList<LocalType> param,
 }
 
 template <size_t index, typename LocalType, typename Input, typename Value>
+    requires (index == ProxyType<LocalType>::fields)
 void ReadOne(TypeList<LocalType> param,
     InvokeContext& invoke_context,
     Input& input,
-    Value& value,
-    typename std::enable_if<index == ProxyType<LocalType>::fields>::type* enable = nullptr)
+    Value& value)
 {
 }
 
 template <typename LocalType, typename Input, typename ReadDest>
+    requires requires { typename ProxyType<LocalType>::Struct; }
 decltype(auto) CustomReadField(TypeList<LocalType> param,
     Priority<1>,
     InvokeContext& invoke_context,
     Input&& input,
-    ReadDest&& read_dest,
-    typename ProxyType<LocalType>::Struct* enable = nullptr)
+    ReadDest&& read_dest)
 {
     return read_dest.update([&](auto& value) { ReadOne<0>(param, invoke_context, input, value); });
 }

--- a/include/mp/type-threadmap.h
+++ b/include/mp/type-threadmap.h
@@ -19,21 +19,21 @@ public:
 };
 
 template <typename Output>
+    requires FieldTypeIs<Output, ThreadMap::Client>
 void CustomBuildField(TypeList<>,
     Priority<1>,
     InvokeContext& invoke_context,
-    Output&& output,
-    typename std::enable_if<std::is_same<decltype(output.get()), ThreadMap::Client>::value>::type* enable = nullptr)
+    Output&& output)
 {
     output.set(kj::heap<ProxyServer<ThreadMap>>(invoke_context.connection));
 }
 
 template <typename Input>
+    requires FieldTypeIs<Input, ThreadMap::Client>
 decltype(auto) CustomReadField(TypeList<>,
     Priority<1>,
     InvokeContext& invoke_context,
-    Input&& input,
-    typename std::enable_if<std::is_same<decltype(input.get()), ThreadMap::Client>::value>::type* enable = nullptr)
+    Input&& input)
 {
     invoke_context.connection.m_thread_map = input.get();
 }

--- a/include/mp/util.h
+++ b/include/mp/util.h
@@ -12,6 +12,8 @@
 #include <cstring>
 #include <exception>
 #include <functional>
+#include <kj/async-io.h>
+#include <kj/memory.h>
 #include <kj/string-tree.h>
 #include <mutex>
 #include <string>
@@ -255,6 +257,8 @@ std::string ThreadName(const char* exe_name);
 //! Escape binary string for use in log so it doesn't trigger unicode decode
 //! errors in python unit tests.
 std::string LogEscape(const kj::StringTree& string, size_t max_size);
+
+using Stream = kj::Own<kj::AsyncIoStream>;
 
 using ProcessId = int;
 using SocketId = int;

--- a/include/mp/util.h
+++ b/include/mp/util.h
@@ -276,10 +276,9 @@ std::tuple<ProcessId, SocketId> SpawnProcess(SpawnConnectInfoToArgsFn&& connect_
 //! returning a socket id for communicating with the parent process.
 SocketId StartSpawned(const SpawnConnectInfo& connect_info);
 
-//! Call execvp with vector args.
-//! Not safe to call in a post-fork child of a multi-threaded process.
-//! Currently only used by mpgen at build time.
-void ExecProcess(const std::vector<std::string>& args);
+//! Start a process and return its process id. Caller should call WaitProcess
+//! on the returned id.
+ProcessId StartProcess(const std::vector<std::string>& args);
 
 //! Wait for a process to exit and return its exit code.
 int WaitProcess(ProcessId pid);

--- a/include/mp/util.h
+++ b/include/mp/util.h
@@ -145,7 +145,10 @@ struct PtrOrValue {
     std::variant<T*, T> data;
 
     template <typename... Args>
-    PtrOrValue(T* ptr, Args&&... args) : data(ptr ? ptr : std::variant<T*, T>{std::in_place_type<T>, std::forward<Args>(args)...}) {}
+    PtrOrValue(T* ptr, Args&&... args) : data(std::in_place_type<T*>, ptr)
+    {
+        if (!ptr) data.template emplace<T>(std::forward<Args>(args)...);
+    }
 
     T& operator*() { return data.index() ? std::get<T>(data) : *std::get<T*>(data); }
     T* operator->() { return &**this; }

--- a/include/mp/util.h
+++ b/include/mp/util.h
@@ -259,17 +259,22 @@ using ProcessId = int;
 using SocketId = int;
 constexpr SocketId SocketError{-1};
 
+//! Information about parent process passed to child process as a command-line
+//! argument. On unix this is the child socket fd number formatted as a string.
+using SpawnConnectInfo = std::string;
+
 //! Callback type used by SpawnProcess below.
-using FdToArgsFn = std::function<std::vector<std::string>(SocketId fd)>;
+using SpawnConnectInfoToArgsFn = std::function<std::vector<std::string>(const SpawnConnectInfo&)>;
 
 //! Spawn a new process that communicates with the current process over a socket
-//! pair. Returns pid through an output argument, and file descriptor for the
-//! local side of the socket.
-//! The fd_to_args callback is invoked in the parent process before fork().
-//! It must not rely on child pid/state, and must return the command line
-//! arguments that should be used to execute the process. Embed the remote file
-//! descriptor number in whatever format the child process expects.
-SocketId SpawnProcess(ProcessId& pid, FdToArgsFn&& fd_to_args);
+//! pair. Calls connect_info_to_args callback with a connection string that
+//! needs to be passed to the child process, and executes the argv command line
+//! it returns. Returns child process id and socket id.
+std::tuple<ProcessId, SocketId> SpawnProcess(SpawnConnectInfoToArgsFn&& connect_info_to_args);
+
+//! Initialize spawned child process using the SpawnConnectInfo string passed to it,
+//! returning a socket id for communicating with the parent process.
+SocketId StartSpawned(const SpawnConnectInfo& connect_info);
 
 //! Call execvp with vector args.
 //! Not safe to call in a post-fork child of a multi-threaded process.

--- a/include/mp/util.h
+++ b/include/mp/util.h
@@ -255,6 +255,8 @@ std::string ThreadName(const char* exe_name);
 //! errors in python unit tests.
 std::string LogEscape(const kj::StringTree& string, size_t max_size);
 
+using ProcessId = int;
+
 //! Callback type used by SpawnProcess below.
 using FdToArgsFn = std::function<std::vector<std::string>(int fd)>;
 
@@ -265,7 +267,7 @@ using FdToArgsFn = std::function<std::vector<std::string>(int fd)>;
 //! It must not rely on child pid/state, and must return the command line
 //! arguments that should be used to execute the process. Embed the remote file
 //! descriptor number in whatever format the child process expects.
-int SpawnProcess(int& pid, FdToArgsFn&& fd_to_args);
+int SpawnProcess(ProcessId& pid, FdToArgsFn&& fd_to_args);
 
 //! Call execvp with vector args.
 //! Not safe to call in a post-fork child of a multi-threaded process.
@@ -273,7 +275,7 @@ int SpawnProcess(int& pid, FdToArgsFn&& fd_to_args);
 void ExecProcess(const std::vector<std::string>& args);
 
 //! Wait for a process to exit and return its exit code.
-int WaitProcess(int pid);
+int WaitProcess(ProcessId pid);
 
 inline char* CharCast(char* c) { return c; }
 inline char* CharCast(unsigned char* c) { return (char*)c; }

--- a/include/mp/util.h
+++ b/include/mp/util.h
@@ -5,6 +5,7 @@
 #ifndef MP_UTIL_H
 #define MP_UTIL_H
 
+#include <array>
 #include <capnp/schema.h>
 #include <cassert>
 #include <cstdlib>
@@ -275,6 +276,10 @@ std::tuple<ProcessId, SocketId> SpawnProcess(SpawnConnectInfoToArgsFn&& connect_
 //! Initialize spawned child process using the SpawnConnectInfo string passed to it,
 //! returning a socket id for communicating with the parent process.
 SocketId StartSpawned(const SpawnConnectInfo& connect_info);
+
+//! Create a socket pair that can be used to communicate within a process or
+//! between parent and child processes.
+std::array<SocketId, 2> SocketPair();
 
 //! Start a process and return its process id. Caller should call WaitProcess
 //! on the returned id.

--- a/include/mp/util.h
+++ b/include/mp/util.h
@@ -256,9 +256,11 @@ std::string ThreadName(const char* exe_name);
 std::string LogEscape(const kj::StringTree& string, size_t max_size);
 
 using ProcessId = int;
+using SocketId = int;
+constexpr SocketId SocketError{-1};
 
 //! Callback type used by SpawnProcess below.
-using FdToArgsFn = std::function<std::vector<std::string>(int fd)>;
+using FdToArgsFn = std::function<std::vector<std::string>(SocketId fd)>;
 
 //! Spawn a new process that communicates with the current process over a socket
 //! pair. Returns pid through an output argument, and file descriptor for the
@@ -267,7 +269,7 @@ using FdToArgsFn = std::function<std::vector<std::string>(int fd)>;
 //! It must not rely on child pid/state, and must return the command line
 //! arguments that should be used to execute the process. Embed the remote file
 //! descriptor number in whatever format the child process expects.
-int SpawnProcess(ProcessId& pid, FdToArgsFn&& fd_to_args);
+SocketId SpawnProcess(ProcessId& pid, FdToArgsFn&& fd_to_args);
 
 //! Call execvp with vector args.
 //! Not safe to call in a post-fork child of a multi-threaded process.

--- a/include/mp/util.h
+++ b/include/mp/util.h
@@ -94,6 +94,16 @@ using RemoveCvRef = std::remove_cv_t<std::remove_reference_t<T>>;
 template <typename T>
 using Decay = std::decay_t<T>;
 
+//! Concept satisfied when T's .get() method returns exactly type U.
+//! Used to constrain overloads that handle a specific capnp field type.
+template <typename T, typename U>
+concept FieldTypeIs = std::is_same_v<decltype(std::declval<T>().get()), U>;
+
+//! Concept satisfied when T's .get() method returns a capnp interface type
+//! (i.e., a type that exposes a nested ::Calls type in generated code).
+template <typename T>
+concept InterfaceField = requires { typename Decay<decltype(std::declval<T>().get())>::Calls; };
+
 //! SFINAE helper, see using Require below.
 template <typename SfinaeExpr, typename Result_>
 struct _Require

--- a/include/mp/version.h
+++ b/include/mp/version.h
@@ -24,7 +24,7 @@
 //! pointing at the prior merge commit. The /doc/versions.md file should also be
 //! updated, noting any significant or incompatible changes made since the
 //! previous version.
-#define MP_MAJOR_VERSION 13
+#define MP_MAJOR_VERSION 14
 
 //! Minor version number. Should be incremented in stable branches after
 //! backporting changes. The /doc/versions.md file should also be updated to

--- a/src/mp/gen.cpp
+++ b/src/mp/gen.cpp
@@ -20,6 +20,7 @@
 #include <kj/common.h>
 #include <kj/filesystem.h>
 #include <kj/memory.h>
+#include <kj/exception.h>
 #include <kj/string.h>
 #include <map>
 #include <set>
@@ -691,35 +692,41 @@ static void Generate(kj::StringPtr src_prefix,
 
 int main(int argc, char** argv)
 {
-    if (argc < 3) {
-        std::cerr << "Usage: " << PROXY_BIN << " SRC_PREFIX INCLUDE_PREFIX SRC_FILE [IMPORT_PATH...]\n";
-        exit(1);
-    }
-    std::vector<kj::StringPtr> import_paths;
-    std::vector<kj::Own<const kj::ReadableDirectory>> import_dirs;
-    auto fs = kj::newDiskFilesystem();
-    auto cwd = fs->getCurrentPath();
-    kj::Own<const kj::ReadableDirectory> src_dir;
-    KJ_IF_MAYBE(dir, fs->getRoot().tryOpenSubdir(cwd.evalNative(argv[1]))) {
-        src_dir = kj::mv(*dir);
-    } else {
-        throw std::runtime_error(std::string("Failed to open src_prefix prefix directory: ") + argv[1]);
-    }
-    for (int i = 4; i < argc; ++i) {
-        KJ_IF_MAYBE(dir, fs->getRoot().tryOpenSubdir(cwd.evalNative(argv[i]))) {
-            import_paths.emplace_back(argv[i]);
-            import_dirs.emplace_back(kj::mv(*dir));
+    int ret = 1;
+    KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() {
+        if (argc < 3) {
+            std::cerr << "Usage: " << PROXY_BIN << " SRC_PREFIX INCLUDE_PREFIX SRC_FILE [IMPORT_PATH...]\n";
+            exit(1);
+        }
+        std::vector<kj::StringPtr> import_paths;
+        std::vector<kj::Own<const kj::ReadableDirectory>> import_dirs;
+        auto fs = kj::newDiskFilesystem();
+        auto cwd = fs->getCurrentPath();
+        kj::Own<const kj::ReadableDirectory> src_dir;
+        KJ_IF_MAYBE(dir, fs->getRoot().tryOpenSubdir(cwd.evalNative(argv[1]))) {
+            src_dir = kj::mv(*dir);
         } else {
-            throw std::runtime_error(std::string("Failed to open import directory: ") + argv[i]);
+            throw std::runtime_error(std::string("Failed to open src_prefix prefix directory: ") + argv[1]);
         }
-    }
-    for (const char* path : {CMAKE_INSTALL_PREFIX "/include", capnp_PREFIX "/include"}) {
-        KJ_IF_MAYBE(dir, fs->getRoot().tryOpenSubdir(cwd.evalNative(path))) {
-            import_paths.emplace_back(path);
-            import_dirs.emplace_back(kj::mv(*dir));
+        for (int i = 4; i < argc; ++i) {
+            KJ_IF_MAYBE(dir, fs->getRoot().tryOpenSubdir(cwd.evalNative(argv[i]))) {
+                import_paths.emplace_back(argv[i]);
+                import_dirs.emplace_back(kj::mv(*dir));
+            } else {
+                throw std::runtime_error(std::string("Failed to open import directory: ") + argv[i]);
+            }
         }
-        // No exception thrown if _PREFIX directories do not exist
+        for (const char* path : {CMAKE_INSTALL_PREFIX "/include", capnp_PREFIX "/include"}) {
+            KJ_IF_MAYBE(dir, fs->getRoot().tryOpenSubdir(cwd.evalNative(path))) {
+                import_paths.emplace_back(path);
+                import_dirs.emplace_back(kj::mv(*dir));
+            }
+            // No exception thrown if _PREFIX directories do not exist
+        }
+        Generate(argv[1], argv[2], argv[3], import_paths, *src_dir, import_dirs);
+        ret = 0;
+    })) {
+        std::cerr << "mpgen error: " << kj::str(*exception).cStr() << '\n';
     }
-    Generate(argv[1], argv[2], argv[3], import_paths, *src_dir, import_dirs);
-    return 0;
+    return ret;
 }

--- a/src/mp/gen.cpp
+++ b/src/mp/gen.cpp
@@ -9,7 +9,6 @@
 #include <capnp/schema.capnp.h> // IWYU pragma: keep
 #include <capnp/schema.h>
 #include <capnp/schema-parser.h>
-#include <cerrno>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -27,8 +26,6 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
-#include <system_error>
-#include <unistd.h>
 #include <utility>
 #include <vector>
 
@@ -284,14 +281,7 @@ static void Generate(kj::StringPtr src_prefix,
     }
     args.emplace_back("--output=" capnp_PREFIX "/bin/capnpc-c++");
     args.emplace_back(src_file);
-    const int pid = fork();
-    if (pid == -1) {
-        throw std::system_error(errno, std::system_category(), "fork");
-    }
-    if (!pid) {
-        mp::ExecProcess(args);
-    }
-    const int status = mp::WaitProcess(pid);
+    const int status = mp::WaitProcess(mp::StartProcess(args));
     if (status) {
         throw std::runtime_error("Invoking " capnp_PREFIX "/bin/capnp failed");
     }

--- a/src/mp/proxy.cpp
+++ b/src/mp/proxy.cpp
@@ -101,7 +101,7 @@ void EventLoopRef::reset(bool relock) MP_NO_TSA
 
 ProxyContext::ProxyContext(Connection* connection) : connection(connection), loop{*connection->m_loop} {}
 
-Connection::~Connection()
+Connection::~Connection() noexcept(false)
 {
     // Connection destructor is always called on the event loop thread. If this
     // is a local disconnect, it will trigger I/O, so this needs to run on the
@@ -120,6 +120,31 @@ Connection::~Connection()
     // executing. In that case, Cap'n Proto will destroy the ProxyServer objects
     // after the calls finish.
     m_rpc_system.reset();
+
+    // shutdownWrite is needed on Windows so pending data in the m_stream socket
+    // will be sent instead of discarded when m_stream is destroyed. On unix,
+    // this doesn't seem to be needed because data is sent more reliably.
+    //
+    // Sending pending data is important if the connection is a socketpair
+    // because when one side of the socketpair is closed, the other side doesn't
+    // seem to receive any onDisconnect event. So it is important for the other
+    // side to instead receive Cap'n Proto "release" messages (see `struct
+    // Release` in capnp/rpc.capnp) from local Client objects being destroyed so
+    // the remote side can free resources and shut down cleanly. Without this,
+    // when one side of a socket pair is closed the other side may not receive
+    // these messages, preventing the remote side from freeing ProxyServer
+    // resources and shutting down cleanly.
+    try {
+        m_stream->shutdownWrite();
+    } catch (const kj::Exception& e) {
+        // Ignore ENOTCONN: on macOS/FreeBSD (unlike Linux), shutdown(SHUT_WR)
+        // returns ENOTCONN if the peer already closed the connection. This is
+        // expected when the destructor is triggered by a remote disconnect.
+        // Also ignore UNIMPLEMENTED: shutdownWrite() may not be supported on
+        // all stream types (e.g. streams that do not support half-close).
+        if (e.getType() != kj::Exception::Type::DISCONNECTED &&
+            e.getType() != kj::Exception::Type::UNIMPLEMENTED) throw;
+    }
 
     // ProxyClient cleanup handlers are in sync list, and ProxyServer cleanup
     // handlers are in the async list.

--- a/src/mp/proxy.cpp
+++ b/src/mp/proxy.cpp
@@ -134,16 +134,23 @@ Connection::~Connection() noexcept(false)
     // when one side of a socket pair is closed the other side may not receive
     // these messages, preventing the remote side from freeing ProxyServer
     // resources and shutting down cleanly.
-    try {
+    // Use kj::runCatchingExceptions instead of try/catch because on macOS with
+    // dynamic libraries, kj::Exception typeinfo differs between libcapnp and
+    // the calling binary, so catch (const kj::Exception&) silently fails to
+    // match. kj::runCatchingExceptions uses KJ's own interception mechanism
+    // which works correctly across dynamic library boundaries.
+    KJ_IF_MAYBE(exception, kj::runCatchingExceptions([&]() {
         m_stream->shutdownWrite();
-    } catch (const kj::Exception& e) {
+    })) {
         // Ignore ENOTCONN: on macOS/FreeBSD (unlike Linux), shutdown(SHUT_WR)
         // returns ENOTCONN if the peer already closed the connection. This is
         // expected when the destructor is triggered by a remote disconnect.
         // Also ignore UNIMPLEMENTED: shutdownWrite() may not be supported on
         // all stream types (e.g. streams that do not support half-close).
-        if (e.getType() != kj::Exception::Type::DISCONNECTED &&
-            e.getType() != kj::Exception::Type::UNIMPLEMENTED) throw;
+        if (exception->getType() != kj::Exception::Type::DISCONNECTED &&
+            exception->getType() != kj::Exception::Type::UNIMPLEMENTED) {
+            kj::throwRecoverableException(kj::mv(*exception));
+        }
     }
 
     // ProxyClient cleanup handlers are in sync list, and ProxyServer cleanup

--- a/src/mp/proxy.cpp
+++ b/src/mp/proxy.cpp
@@ -42,6 +42,15 @@ namespace mp {
 
 thread_local ThreadContext g_thread_context; // NOLINT(bitcoin-nontrivial-threadlocal)
 
+Stream MakeStream(EventLoop&loop, SocketId socket)
+{
+    Stream stream;
+    loop.sync([&]() {
+        stream = loop.m_io_context.lowLevelProvider->wrapSocketFd(socket, kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP);
+    });
+    return stream;
+}
+
 void LoggingErrorHandler::taskFailed(kj::Exception&& exception)
 {
     KJ_LOG(ERROR, "Uncaught exception in daemonized task.", exception);

--- a/src/mp/proxy.cpp
+++ b/src/mp/proxy.cpp
@@ -206,7 +206,7 @@ EventLoop::EventLoop(const char* exe_name, LogOptions log_opts, void* context)
       m_log_opts(std::move(log_opts)),
       m_context(context)
 {
-    int fds[2];
+    SocketId fds[2];
     KJ_SYSCALL(socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
     m_wait_fd = fds[0];
     m_post_fd = fds[1];
@@ -218,8 +218,8 @@ EventLoop::~EventLoop()
     const Lock lock(m_mutex);
     KJ_ASSERT(m_post_fn == nullptr);
     KJ_ASSERT(!m_async_fns);
-    KJ_ASSERT(m_wait_fd == -1);
-    KJ_ASSERT(m_post_fd == -1);
+    KJ_ASSERT(m_wait_fd == SocketError);
+    KJ_ASSERT(m_post_fd == SocketError);
     KJ_ASSERT(m_num_refs == 0);
 
     // Spin event loop. wait for any promises triggered by RPC shutdown.
@@ -270,8 +270,8 @@ void EventLoop::loop()
     wait_stream = nullptr;
     KJ_SYSCALL(::close(post_fd));
     const Lock lock(m_mutex);
-    m_wait_fd = -1;
-    m_post_fd = -1;
+    m_wait_fd = SocketError;
+    m_post_fd = SocketError;
     m_async_fns.reset();
     m_cv.notify_all();
 }

--- a/src/mp/proxy.cpp
+++ b/src/mp/proxy.cpp
@@ -24,6 +24,7 @@
 #include <kj/debug.h>
 #include <kj/exception.h>
 #include <kj/function.h>
+#include <kj/io.h>
 #include <kj/memory.h>
 #include <kj/string.h>
 #include <cstdint>
@@ -32,10 +33,8 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
-#include <sys/socket.h>
 #include <thread>
 #include <tuple>
-#include <unistd.h>
 #include <utility>
 #include <vector>
 
@@ -69,10 +68,20 @@ void EventLoopRef::reset(bool relock) MP_NO_TSA
         loop->m_num_refs -= 1;
         if (loop->done()) {
             loop->m_cv.notify_all();
-            int post_fd{loop->m_post_fd};
+            // Capture loop->m_post_writer pointer before releasing the lock.
+            // The pointer can't actually change before the write() call below,
+            // but copying it with the lock held instead of accessing it
+            // directly below prevents TSAN false positives because TSAN is
+            // unaware of socketpair write() synchronization and might falsely
+            // report the pointer being used in this thread and assigned in the
+            // other thread without synchronization between.
+            kj::OutputStream* post_writer{loop->m_post_writer.get()};
             loop_lock->unlock();
             char buffer = 0;
-            KJ_SYSCALL(write(post_fd, &buffer, 1)); // NOLINT(bugprone-suspicious-semicolon)
+            // It safe to access post_writer here because the loop can't
+            // exit until this write takes place. See "Intentionally do not
+            // break..."  comment in EventLoop::loop
+            post_writer->write(&buffer, 1);
             // By default, do not try to relock `loop_lock` after writing,
             // because the event loop could wake up and destroy itself and the
             // mutex might no longer exist.
@@ -206,10 +215,14 @@ EventLoop::EventLoop(const char* exe_name, LogOptions log_opts, void* context)
       m_log_opts(std::move(log_opts)),
       m_context(context)
 {
-    SocketId fds[2];
-    KJ_SYSCALL(socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
-    m_wait_fd = fds[0];
-    m_post_fd = fds[1];
+    auto pipe = m_io_context.provider->newTwoWayPipe();
+    m_wait_stream = kj::mv(pipe.ends[0]);
+    m_post_stream = kj::mv(pipe.ends[1]);
+    KJ_IF_MAYBE(fd, m_post_stream->getFd()) {
+        m_post_writer = kj::heap<kj::FdOutputStream>(*fd);
+    } else {
+        throw std::logic_error("Could not get file descriptor for new pipe.");
+    }
 }
 
 EventLoop::~EventLoop()
@@ -218,8 +231,8 @@ EventLoop::~EventLoop()
     const Lock lock(m_mutex);
     KJ_ASSERT(m_post_fn == nullptr);
     KJ_ASSERT(!m_async_fns);
-    KJ_ASSERT(m_wait_fd == SocketError);
-    KJ_ASSERT(m_post_fd == SocketError);
+    KJ_ASSERT(!m_wait_stream);
+    KJ_ASSERT(!m_post_stream);
     KJ_ASSERT(m_num_refs == 0);
 
     // Spin event loop. wait for any promises triggered by RPC shutdown.
@@ -239,9 +252,7 @@ void EventLoop::loop()
         m_async_fns.emplace();
     }
 
-    kj::Own<kj::AsyncIoStream> wait_stream{
-        m_io_context.lowLevelProvider->wrapSocketFd(m_wait_fd, kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP)};
-    int post_fd{m_post_fd};
+    kj::Own<kj::AsyncIoStream>& wait_stream{m_wait_stream};
     char buffer = 0;
     for (;;) {
         const size_t read_bytes = wait_stream->read(&buffer, 0, 1).wait(m_io_context.waitScope);
@@ -258,7 +269,7 @@ void EventLoop::loop()
             m_cv.notify_all();
         } else if (done()) {
             // Intentionally do not break if m_post_fn was set, even if done()
-            // would return true, to ensure that the EventLoopRef write(post_fd)
+            // would return true, to ensure that the post() m_post_writer->write()
             // call always succeeds and the loop does not exit between the time
             // that the done condition is set and the write call is made.
             break;
@@ -268,10 +279,10 @@ void EventLoop::loop()
     m_task_set.reset();
     MP_LOG(*this, Log::Info) << "EventLoop::loop bye.";
     wait_stream = nullptr;
-    KJ_SYSCALL(::close(post_fd));
     const Lock lock(m_mutex);
-    m_wait_fd = SocketError;
-    m_post_fd = SocketError;
+    m_post_writer = nullptr;
+    m_wait_stream = nullptr;
+    m_post_stream = nullptr;
     m_async_fns.reset();
     m_cv.notify_all();
 }
@@ -286,10 +297,9 @@ void EventLoop::post(kj::Function<void()> fn)
     EventLoopRef ref(*this, &lock);
     m_cv.wait(lock.m_lock, [this]() MP_REQUIRES(m_mutex) { return m_post_fn == nullptr; });
     m_post_fn = &fn;
-    int post_fd{m_post_fd};
     Unlock(lock, [&] {
         char buffer = 0;
-        KJ_SYSCALL(write(post_fd, &buffer, 1));
+        m_post_writer->write(&buffer, 1);
     });
     m_cv.wait(lock.m_lock, [this, &fn]() MP_REQUIRES(m_mutex) { return m_post_fn != &fn; });
 }

--- a/src/mp/util.cpp
+++ b/src/mp/util.cpp
@@ -183,7 +183,7 @@ void ExecProcess(const std::vector<std::string>& args)
     }
 }
 
-int WaitProcess(int pid)
+int WaitProcess(ProcessId pid)
 {
     int status;
     if (::waitpid(pid, &status, /*options=*/0) != pid) {

--- a/src/mp/util.cpp
+++ b/src/mp/util.cpp
@@ -116,9 +116,9 @@ std::string LogEscape(const kj::StringTree& string, size_t max_size)
     return result;
 }
 
-int SpawnProcess(int& pid, FdToArgsFn&& fd_to_args)
+SocketId SpawnProcess(ProcessId& pid, FdToArgsFn&& fd_to_args)
 {
-    int fds[2];
+    SocketId fds[2];
     if (socketpair(AF_UNIX, SOCK_STREAM, 0, fds) != 0) {
         throw std::system_error(errno, std::system_category(), "socketpair");
     }

--- a/src/mp/util.cpp
+++ b/src/mp/util.cpp
@@ -7,14 +7,14 @@
 
 #include <cerrno>
 #include <cstdio>
-#include <filesystem>
-#include <iostream>
 #include <kj/common.h>
+#include <kj/debug.h>
 #include <kj/string-tree.h>
 #include <pthread.h>
 #include <sstream>
 #include <string>
 #include <sys/types.h>
+#include <spawn.h>
 #include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/wait.h>
@@ -32,7 +32,7 @@
 #include <pthread_np.h>
 #endif // HAVE_PTHREAD_GETTHREADID_NP
 
-namespace fs = std::filesystem;
+extern "C" char **environ; // NOLINT(readability-redundant-declaration)
 
 namespace mp {
 namespace {
@@ -181,16 +181,14 @@ SocketId StartSpawned(const SpawnConnectInfo& connect_info)
     }
 }
 
-void ExecProcess(const std::vector<std::string>& args)
+ProcessId StartProcess(const std::vector<std::string>& args)
 {
     const std::vector<char*> argv{MakeArgv(args)};
-    if (execvp(argv[0], argv.data()) != 0) {
-        perror("execvp failed");
-        if (errno == ENOENT && !args.empty()) {
-            std::cerr << "Missing executable: " << fs::weakly_canonical(args.front()) << '\n';
-        }
-        _exit(1);
+    ProcessId pid;
+    if (int err = posix_spawnp(&pid, argv[0], nullptr, nullptr, argv.data(), ::environ)) {
+        KJ_FAIL_SYSCALL("posix_spawnp", err, args.front());
     }
+    return pid;
 }
 
 int WaitProcess(ProcessId pid)

--- a/src/mp/util.cpp
+++ b/src/mp/util.cpp
@@ -116,7 +116,7 @@ std::string LogEscape(const kj::StringTree& string, size_t max_size)
     return result;
 }
 
-SocketId SpawnProcess(ProcessId& pid, FdToArgsFn&& fd_to_args)
+std::tuple<ProcessId, SocketId> SpawnProcess(SpawnConnectInfoToArgsFn&& connect_info_to_args)
 {
     SocketId fds[2];
     if (socketpair(AF_UNIX, SOCK_STREAM, 0, fds) != 0) {
@@ -129,10 +129,10 @@ SocketId SpawnProcess(ProcessId& pid, FdToArgsFn&& fd_to_args)
     // locks at fork time. In that case, running code that allocates memory or
     // takes locks in the child between fork() and exec() can deadlock
     // indefinitely. Precomputing arguments in the parent avoids this.
-    const std::vector<std::string> args{fd_to_args(fds[0])};
+    const std::vector<std::string> args{connect_info_to_args(std::to_string(fds[0]))};
     const std::vector<char*> argv{MakeArgv(args)};
 
-    pid = fork();
+    ProcessId pid = fork();
     if (pid == -1) {
         throw std::system_error(errno, std::system_category(), "fork");
     }
@@ -168,7 +168,17 @@ SocketId SpawnProcess(ProcessId& pid, FdToArgsFn&& fd_to_args)
         perror("execvp failed");
         _exit(127);
     }
-    return fds[1];
+    return {pid, fds[1]};
+}
+
+SocketId StartSpawned(const SpawnConnectInfo& connect_info)
+{
+    try {
+        return std::stoi(connect_info);
+    } catch (const std::exception&) {
+        throw std::system_error(EINVAL, std::system_category(),
+            std::string("StartSpawned: invalid connect_info '") + connect_info + "'");
+    }
 }
 
 void ExecProcess(const std::vector<std::string>& args)

--- a/src/mp/util.cpp
+++ b/src/mp/util.cpp
@@ -7,6 +7,7 @@
 
 #include <cerrno>
 #include <cstdio>
+#include <fcntl.h>
 #include <kj/common.h>
 #include <kj/debug.h>
 #include <kj/string-tree.h>
@@ -118,10 +119,7 @@ std::string LogEscape(const kj::StringTree& string, size_t max_size)
 
 std::tuple<ProcessId, SocketId> SpawnProcess(SpawnConnectInfoToArgsFn&& connect_info_to_args)
 {
-    SocketId fds[2];
-    if (socketpair(AF_UNIX, SOCK_STREAM, 0, fds) != 0) {
-        throw std::system_error(errno, std::system_category(), "socketpair");
-    }
+    auto fds{SocketPair()};
 
     // Evaluate the callback and build the argv array before forking.
     //
@@ -131,6 +129,11 @@ std::tuple<ProcessId, SocketId> SpawnProcess(SpawnConnectInfoToArgsFn&& connect_
     // indefinitely. Precomputing arguments in the parent avoids this.
     const std::vector<std::string> args{connect_info_to_args(std::to_string(fds[0]))};
     const std::vector<char*> argv{MakeArgv(args)};
+
+    // Clear FD_CLOEXEC on fds[0] before forking so it survives exec in the child.
+    int fds0_flags;
+    KJ_SYSCALL(fds0_flags = fcntl(fds[0], F_GETFD));
+    KJ_SYSCALL(fcntl(fds[0], F_SETFD, fds0_flags & ~FD_CLOEXEC));
 
     ProcessId pid = fork();
     if (pid == -1) {
@@ -179,6 +182,15 @@ SocketId StartSpawned(const SpawnConnectInfo& connect_info)
         throw std::system_error(EINVAL, std::system_category(),
             std::string("StartSpawned: invalid connect_info '") + connect_info + "'");
     }
+}
+
+std::array<SocketId, 2> SocketPair()
+{
+    int pair[2];
+    KJ_SYSCALL(socketpair(AF_UNIX, SOCK_STREAM, 0, pair));
+    KJ_SYSCALL(fcntl(pair[0], F_SETFD, FD_CLOEXEC));
+    KJ_SYSCALL(fcntl(pair[1], F_SETFD, FD_CLOEXEC));
+    return {pair[0], pair[1]};
 }
 
 ProcessId StartProcess(const std::vector<std::string>& args)

--- a/test/mp/test/listen_tests.cpp
+++ b/test/mp/test/listen_tests.cpp
@@ -108,7 +108,7 @@ public:
                   KJ_LOG(INFO, log.level, log.message);
                   if (log.level == mp::Log::Raise) throw std::runtime_error(log.message);
               });
-              client_promise.set_value(ConnectStream<messages::FooInterface>(loop, fd));
+              client_promise.set_value(ConnectStream<messages::FooInterface>(loop, MakeStream(loop, fd)));
               loop.loop();
           })
     {

--- a/test/mp/test/spawn_tests.cpp
+++ b/test/mp/test/spawn_tests.cpp
@@ -89,7 +89,7 @@ KJ_TEST("SpawnProcess does not run callback in child")
     });
 
     ProcessId pid{-1};
-    const int fd{SpawnProcess(pid, [&](int child_fd) -> std::vector<std::string> {
+    const SocketId fd{SpawnProcess(pid, [&](SocketId child_fd) -> std::vector<std::string> {
         // If this callback runs in the post-fork child, target_mutex appears
         // locked forever (the owning thread does not exist), so this deadlocks.
         std::lock_guard<std::mutex> g(target_mutex);

--- a/test/mp/test/spawn_tests.cpp
+++ b/test/mp/test/spawn_tests.cpp
@@ -18,6 +18,8 @@
 #include <unistd.h>
 #include <vector>
 
+namespace mp {
+namespace test {
 namespace {
 
 constexpr auto FAILURE_TIMEOUT = std::chrono::seconds{30};
@@ -25,7 +27,7 @@ constexpr auto FAILURE_TIMEOUT = std::chrono::seconds{30};
 // Poll for child process exit using waitpid(..., WNOHANG) until the child exits
 // or timeout expires. Returns true if the child exited and status_out was set.
 // Returns false on timeout or error.
-static bool WaitPidWithTimeout(int pid, std::chrono::milliseconds timeout, int& status_out)
+static bool WaitPidWithTimeout(ProcessId pid, std::chrono::milliseconds timeout, int& status_out)
 {
     const auto deadline = std::chrono::steady_clock::now() + timeout;
     while (std::chrono::steady_clock::now() < deadline) {
@@ -86,8 +88,8 @@ KJ_TEST("SpawnProcess does not run callback in child")
         control_cv.notify_one();
     });
 
-    int pid{-1};
-    const int fd{mp::SpawnProcess(pid, [&](int child_fd) -> std::vector<std::string> {
+    ProcessId pid{-1};
+    const int fd{SpawnProcess(pid, [&](int child_fd) -> std::vector<std::string> {
         // If this callback runs in the post-fork child, target_mutex appears
         // locked forever (the owning thread does not exist), so this deadlocks.
         std::lock_guard<std::mutex> g(target_mutex);
@@ -110,3 +112,5 @@ KJ_TEST("SpawnProcess does not run callback in child")
     KJ_EXPECT(exited, "Timeout waiting for child process to exit");
     KJ_EXPECT(WIFEXITED(status) && WEXITSTATUS(status) == 0);
 }
+} // namespace test
+} // namespace mp

--- a/test/mp/test/spawn_tests.cpp
+++ b/test/mp/test/spawn_tests.cpp
@@ -15,7 +15,9 @@
 #include <string>
 #include <sys/wait.h>
 #include <thread>
+#include <tuple>
 #include <unistd.h>
+#include <utility>
 #include <vector>
 
 namespace mp {
@@ -88,14 +90,13 @@ KJ_TEST("SpawnProcess does not run callback in child")
         control_cv.notify_one();
     });
 
-    ProcessId pid{-1};
-    const SocketId fd{SpawnProcess(pid, [&](SocketId child_fd) -> std::vector<std::string> {
+    const auto [pid, socket]{SpawnProcess([&](SpawnConnectInfo connect_info) -> std::vector<std::string> {
         // If this callback runs in the post-fork child, target_mutex appears
         // locked forever (the owning thread does not exist), so this deadlocks.
         std::lock_guard<std::mutex> g(target_mutex);
-        return {"true", std::to_string(child_fd)};
+        return {"true", std::move(connect_info)};
     })};
-    ::close(fd);
+    ::close(socket);
 
     int status{0};
     // Give the child some time to exit. If it does not, terminate it and


### PR DESCRIPTION
This PR implements API changes and fixes needed to allow libmultiprocess to work on nonunix platforms.

These changes were originally part of #231, which adds windows support, but were split out to allow windows and nonwindows changes to be reviewed separately.