### PR TITLE
Add std::unordered_set support and a helper BuildList to dedup list build handlers

### DIFF
--- a/include/mp/proxy-types.h
+++ b/include/mp/proxy-types.h
@@ -281,6 +281,17 @@ struct ListOutput<::capnp::List<T, kind>>
 };
 
 template <typename LocalType, typename Value, typename Output>
+void BuildList(TypeList<LocalType>, InvokeContext& invoke_context, Output&& output, Value&& value)
+{
+    auto list = output.init(value.size());
+    size_t i = 0;
+    for (const auto& elem : value) {
+        BuildField(TypeList<LocalType>(), invoke_context, ListOutput<typename decltype(list)::Builds>(list, i), elem);
+        ++i;
+    }
+}
+
+template <typename LocalType, typename Value, typename Output>
 void CustomBuildField(TypeList<LocalType>, Priority<0>, InvokeContext& invoke_context, Value&& value, Output&& output)
 {
     output.set(BuildPrimitive(invoke_context, std::forward<Value>(value), TypeList<decltype(output.get())>()));

--- a/include/mp/type-map.h
+++ b/include/mp/type-map.h
@@ -17,14 +17,7 @@ void CustomBuildField(TypeList<std::map<KeyLocalType, ValueLocalType>>,
     Value&& value,
     Output&& output)
 {
-    // FIXME dededup with vector handler above
-    auto list = output.init(value.size());
-    size_t i = 0;
-    for (const auto& elem : value) {
-        BuildField(TypeList<std::pair<KeyLocalType, ValueLocalType>>(), invoke_context,
-            ListOutput<typename decltype(list)::Builds>(list, i), elem);
-        ++i;
-    }
+    BuildList(TypeList<std::pair<KeyLocalType, ValueLocalType>>(), invoke_context, output, value);
 }
 
 // Replacement for `m.emplace(piecewise_construct, t1, t2)` to work around a

--- a/include/mp/type-set.h
+++ b/include/mp/type-set.h
@@ -16,13 +16,7 @@ void CustomBuildField(TypeList<std::set<LocalType>>,
     Value&& value,
     Output&& output)
 {
-    // FIXME dededup with vector handler above
-    auto list = output.init(value.size());
-    size_t i = 0;
-    for (const auto& elem : value) {
-        BuildField(TypeList<LocalType>(), invoke_context, ListOutput<typename decltype(list)::Builds>(list, i), elem);
-        ++i;
-    }
+    BuildList(TypeList<LocalType>(), invoke_context, output, value);
 }
 
 template <typename LocalType, typename Input, typename ReadDest>

--- a/include/mp/type-unordered-set.h
+++ b/include/mp/type-unordered-set.h
@@ -1,0 +1,43 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef MP_PROXY_TYPE_UNORDERED_SET_H
+#define MP_PROXY_TYPE_UNORDERED_SET_H
+
+#include <mp/proxy-types.h>
+#include <mp/util.h>
+#include <unordered_set>
+
+namespace mp {
+template <typename LocalType, typename Value, typename Output>
+void CustomBuildField(TypeList<std::unordered_set<LocalType>>,
+    Priority<1>,
+    InvokeContext& invoke_context,
+    Value&& value,
+    Output&& output)
+{
+    BuildList(TypeList<LocalType>(), invoke_context, output, value);
+}
+
+template <typename LocalType, typename Input, typename ReadDest>
+decltype(auto) CustomReadField(TypeList<std::unordered_set<LocalType>>,
+    Priority<1>,
+    InvokeContext& invoke_context,
+    Input&& input,
+    ReadDest&& read_dest)
+{
+    return read_dest.update([&](auto& value) {
+        auto data = input.get();
+        value.clear();
+        for (auto item : data) {
+            ReadField(TypeList<LocalType>(), invoke_context, Make<ValueField>(item),
+                ReadDestEmplace(TypeList<const LocalType>(), [&](auto&&... args) -> auto& {
+                    return *value.emplace(std::forward<decltype(args)>(args)...).first;
+                }));
+        }
+    });
+}
+} // namespace mp
+
+#endif // MP_PROXY_TYPE_UNORDERED_SET_H

--- a/include/mp/type-vector.h
+++ b/include/mp/type-vector.h
@@ -16,12 +16,7 @@ void CustomBuildField(TypeList<std::vector<LocalType>>,
     Value&& value,
     Output&& output)
 {
-    // FIXME dedup with set handler below
-    auto list = output.init(value.size());
-    size_t i = 0;
-    for (auto it = value.begin(); it != value.end(); ++it, ++i) {
-        BuildField(TypeList<LocalType>(), invoke_context, ListOutput<typename decltype(list)::Builds>(list, i), *it);
-    }
+    BuildList(TypeList<LocalType>(), invoke_context, output, value);
 }
 
 inline static bool BuildPrimitive(InvokeContext& invoke_context, std::vector<bool>::const_reference value, TypeList<bool>)

--- a/test/mp/test/foo-types.h
+++ b/test/mp/test/foo-types.h
@@ -26,6 +26,7 @@
 #include <mp/type-string.h>
 #include <mp/type-struct.h>
 #include <mp/type-threadmap.h>
+#include <mp/type-unordered-set.h>
 #include <mp/type-vector.h>
 #include <string>
 #include <type_traits>

--- a/test/mp/test/foo.capnp
+++ b/test/mp/test/foo.capnp
@@ -57,6 +57,7 @@ struct FooStruct $Proxy.wrap("mp::test::FooStruct") {
     vbool @2 :List(Bool);
     optionalInt @3 :Int32 $Proxy.name("optional_int");
     hasOptionalInt @4 :Bool;
+    unorderedsetint @5 :List(Int32);
 }
 
 struct FooCustom $Proxy.wrap("mp::test::FooCustom") {

--- a/test/mp/test/foo.capnp
+++ b/test/mp/test/foo.capnp
@@ -53,11 +53,11 @@ interface FooFn $Proxy.wrap("ProxyCallback<std::function<int()>>") {
 
 struct FooStruct $Proxy.wrap("mp::test::FooStruct") {
     name @0 :Text;
-    setint @1 :List(Int32);
-    vbool @2 :List(Bool);
+    setInt @1 :List(Int32) $Proxy.name("set_int");
+    vBool @2 :List(Bool) $Proxy.name("v_bool");
     optionalInt @3 :Int32 $Proxy.name("optional_int");
     hasOptionalInt @4 :Bool;
-    unorderedsetint @5 :List(Int32);
+    unorderedSetInt @5 :List(Int32) $Proxy.name("unordered_set_int");
 }
 
 struct FooCustom $Proxy.wrap("mp::test::FooCustom") {

--- a/test/mp/test/foo.h
+++ b/test/mp/test/foo.h
@@ -21,10 +21,10 @@ namespace test {
 struct FooStruct
 {
     std::string name;
-    std::set<int> setint;
-    std::vector<bool> vbool;
+    std::set<int> set_int;
+    std::vector<bool> v_bool;
     std::optional<int> optional_int;
-    std::unordered_set<int> unorderedsetint;
+    std::unordered_set<int> unordered_set_int;
 };
 
 enum class FooEnum : uint8_t { ONE = 1, TWO = 2, };

--- a/test/mp/test/foo.h
+++ b/test/mp/test/foo.h
@@ -12,6 +12,7 @@
 #include <optional>
 #include <string>
 #include <set>
+#include <unordered_set>
 #include <vector>
 
 namespace mp {
@@ -23,6 +24,7 @@ struct FooStruct
     std::set<int> setint;
     std::vector<bool> vbool;
     std::optional<int> optional_int;
+    std::unordered_set<int> unorderedsetint;
 };
 
 enum class FooEnum : uint8_t { ONE = 1, TWO = 2, };

--- a/test/mp/test/test.cpp
+++ b/test/mp/test/test.cpp
@@ -34,6 +34,7 @@
 #include <string_view>
 #include <thread>
 #include <type_traits>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -143,6 +144,8 @@ KJ_TEST("Call FooInterface methods")
     in.name = "name";
     in.setint.insert(2);
     in.setint.insert(1);
+    in.unorderedsetint.insert(2);
+    in.unorderedsetint.insert(1);
     in.vbool.push_back(false);
     in.vbool.push_back(true);
     in.vbool.push_back(false);
@@ -152,6 +155,10 @@ KJ_TEST("Call FooInterface methods")
     KJ_EXPECT(in.setint.size() == out.setint.size());
     for (auto init{in.setint.begin()}, outit{out.setint.begin()}; init != in.setint.end() && outit != out.setint.end(); ++init, ++outit) {
         KJ_EXPECT(*init == *outit);
+    }
+    KJ_EXPECT(in.unorderedsetint.size() == out.unorderedsetint.size());
+    for (const auto& elem : in.unorderedsetint) {
+        KJ_EXPECT(out.unorderedsetint.count(elem) == 1);
     }
     KJ_EXPECT(in.vbool.size() == out.vbool.size());
     for (size_t i = 0; i < in.vbool.size(); ++i) {

--- a/test/mp/test/test.cpp
+++ b/test/mp/test/test.cpp
@@ -142,27 +142,27 @@ KJ_TEST("Call FooInterface methods")
 
     FooStruct in;
     in.name = "name";
-    in.setint.insert(2);
-    in.setint.insert(1);
-    in.unorderedsetint.insert(2);
-    in.unorderedsetint.insert(1);
-    in.vbool.push_back(false);
-    in.vbool.push_back(true);
-    in.vbool.push_back(false);
+    in.set_int.insert(2);
+    in.set_int.insert(1);
+    in.unordered_set_int.insert(2);
+    in.unordered_set_int.insert(1);
+    in.v_bool.push_back(false);
+    in.v_bool.push_back(true);
+    in.v_bool.push_back(false);
     in.optional_int = 3;
     FooStruct out = foo->pass(in);
     KJ_EXPECT(in.name == out.name);
-    KJ_EXPECT(in.setint.size() == out.setint.size());
-    for (auto init{in.setint.begin()}, outit{out.setint.begin()}; init != in.setint.end() && outit != out.setint.end(); ++init, ++outit) {
+    KJ_EXPECT(in.set_int.size() == out.set_int.size());
+    for (auto init{in.set_int.begin()}, outit{out.set_int.begin()}; init != in.set_int.end() && outit != out.set_int.end(); ++init, ++outit) {
         KJ_EXPECT(*init == *outit);
     }
-    KJ_EXPECT(in.unorderedsetint.size() == out.unorderedsetint.size());
-    for (const auto& elem : in.unorderedsetint) {
-        KJ_EXPECT(out.unorderedsetint.count(elem) == 1);
+    KJ_EXPECT(in.unordered_set_int.size() == out.unordered_set_int.size());
+    for (const auto& elem : in.unordered_set_int) {
+        KJ_EXPECT(out.unordered_set_int.count(elem) == 1);
     }
-    KJ_EXPECT(in.vbool.size() == out.vbool.size());
-    for (size_t i = 0; i < in.vbool.size(); ++i) {
-        KJ_EXPECT(in.vbool[i] == out.vbool[i]);
+    KJ_EXPECT(in.v_bool.size() == out.v_bool.size());
+    for (size_t i = 0; i < in.v_bool.size(); ++i) {
+        KJ_EXPECT(in.v_bool[i] == out.v_bool[i]);
     }
     KJ_EXPECT(in.optional_int == out.optional_int);
 


### PR DESCRIPTION
Add std::unordered_set support and a helper BuildList to dedup list build handlers that is being used for map, set and vector.

While looking bitcoin/bitcoin#29409, found a TODO noting that libmultiprocess lacked std::unordered_set support, requiring downstream that PR to implement the build/read functions locally.

I believe there could be more dedup adding a ReadList too. I could do that as a follow-up if desirable