### PR TITLE
build: exclude mptest target from compile commands

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,4 +37,5 @@ if(BUILD_TESTING AND TARGET CapnProto::kj-test)
 
   add_dependencies(mptests mptest)
   add_test(NAME mptest COMMAND mptest)
+  set_target_properties(mptest PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
 endif()


### PR DESCRIPTION
build: exclude mptest target from compile commands

Excludes mptest from compile_commands.json because it includes generated
.capnp.h files that don't exist at configure time, causing IWYU failures
when this repo is used as a subtree in Bitcoin Core.

Follows the pattern established for example targets.

Refs bitcoin/bitcoin#35361 (this change will resolve that issue once pulled into Bitcoin Core)