### PR TITLE
proxy-client: fix TSan data race in clientDestroy

### DIFF
--- a/include/mp/proxy-types.h
+++ b/include/mp/proxy-types.h
@@ -644,11 +644,7 @@ struct CapRequestTraits<::capnp::Request<_Params, _Results>>
 template <typename Client>
 void clientDestroy(Client& client)
 {
-    if (client.m_context.connection) {
-        MP_LOG(*client.m_context.loop, Log::Debug) << "IPC client destroy " << CxxTypeName(client);
-    } else {
-        KJ_LOG(INFO, "IPC interrupted client destroy", CxxTypeName(client));
-    }
+    MP_LOG(*client.m_context.loop, Log::Debug) << "IPC client destroy " << CxxTypeName(client);
 }
 
 template <typename Server>

--- a/src/mp/gen.cpp
+++ b/src/mp/gen.cpp
@@ -6,6 +6,7 @@
 #include <mp/util.h>
 
 #include <algorithm>
+#include <capnp/schema.capnp.h> // IWYU pragma: keep
 #include <capnp/schema.h>
 #include <capnp/schema-parser.h>
 #include <cerrno>
@@ -329,12 +330,17 @@ static void Generate(kj::StringPtr src_prefix,
     cpp_client << "#include <" << include_path << ".h>\n";
     cpp_client << "#include <" << include_path << ".proxy.h>\n";
     cpp_client << "#include <" << include_path << ".proxy-types.h>\n";
+    cpp_client << "#include <capnp/capability.h>\n";
+    cpp_client << "#include <capnp/common.h>\n";
     cpp_client << "#include <capnp/generated-header-support.h>\n";
     cpp_client << "#include <cstring>\n";
-    cpp_client << "#include <vector>\n";
+    cpp_client << "#include <functional>\n";
     cpp_client << "#include <kj/common.h>\n";
+    cpp_client << "#include <map>\n";
     cpp_client << "#include <mp/proxy.h>\n";
     cpp_client << "#include <mp/util.h>\n";
+    cpp_client << "#include <string>\n";
+    cpp_client << "#include <vector>\n";
     cpp_client << "#include <" << PROXY_TYPES << ">\n";
     cpp_client << "// IWYU pragma: end_keep\n\n";
     cpp_client << "namespace mp {\n";
@@ -346,8 +352,6 @@ static void Generate(kj::StringPtr src_prefix,
     cpp_types << "#include <" << include_path << ".h> // IWYU pragma: keep\n";
     cpp_types << "#include <" << include_path << ".proxy.h>\n";
     cpp_types << "#include <" << include_path << ".proxy-types.h> // IWYU pragma: keep\n";
-    cpp_types << "#include <kj/common.h>\n";
-    cpp_types << "#include <mp/util.h>\n";
     cpp_types << "#include <" << PROXY_TYPES << ">\n\n";
     cpp_types << "namespace mp {\n";
 


### PR DESCRIPTION
#273 added a new test which exposed a longstanding race condition in `clientDestroy` logging code, causing the sanitize CI job to now fail with a TSAN error. Fix the race by simplifying the logging code.

Details about the fix are in the commit message. TSAN error looked like

```
[ TEST ] test.cpp:437: Destroying ProxyClient<> with destroy method after peer disconnect
...
  Write of size 8 at 0x721400005020 by thread T24 (mutexes: write M0):
    #0 std::__1::__function::__func<mp::ProxyClientBase<mp::test::messages::FooCallback, mp::test::FooCallback>::ProxyClientBase(mp::test::messages::FooCallback::Client, mp::Connection*, bool)::{lambda()#1}, void ()>::operator()() /home/runner/work/libmultiprocess/libmultiprocess/include/mp/proxy-io.h:522 (mptest+0x242b20)
    #1 void mp::Unlock<mp::Lock, std::__1::function<void ()>&>(mp::Lock&, std::__1::function<void ()>&) /nix/store/6z6xj37ljxwrwd5w3rs0zyfkrxd48lzl-libcxx-21.1.2-dev/include/c++/v1/__functional/function.h:274 (mptest+0x35582d)
    #2 mp::Connection::~Connection() /home/runner/work/libmultiprocess/libmultiprocess/src/mp/proxy.cpp:150 (mptest+0x34e596)
    ...
    #11 mp::test::TestSetup::TestSetup(bool)::{lambda()#1}::operator()() const /home/runner/work/libmultiprocess/libmultiprocess/test/mp/test/test.cpp:112 (mptest+0x1504fe)

  Previous read of size 8 at 0x721400005020 by thread T26:
    #0 void mp::clientDestroy<mp::ProxyClient<mp::test::messages::FooCallback> >(mp::ProxyClient<mp::test::messages::FooCallback>&) /home/runner/work/libmultiprocess/libmultiprocess/include/mp/proxy-types.h:647 (mptest+0x342d2a)
     ...
    #21 std::__1::__function::__func<mp::ProxyServerBase<mp::test::messages::FooInterface, mp::test::FooImplementation>::~ProxyServerBase()::{lambda()#1}, void ()>::operator()() /nix/store/6z6xj37ljxwrwd5w3rs0zyfkrxd48lzl-libcxx-21.1.2-dev/include/c++/v1/__functional/function.h:174 (mptest+0x347c76)
     ...
    #23 void* std::__1::__thread_proxy[abi:ne210101]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, mp::EventLoop::startAsyncThread()::$_0> >(void*) /home/runner/work/libmultiprocess/libmultiprocess/src/mp/proxy.cpp:309 (mptest+0x353ef2)

  Thread T24 (tid=10032, running) created by main thread at:
    ...
    #4 mp::test::TestCase437::run() /home/runner/work/libmultiprocess/libmultiprocess/test/mp/test/test.cpp:449 (mptest+0x1459a7)

```

https://github.com/bitcoin-core/libmultiprocess/actions/runs/26851297744/job/79183796152

Note: #273 made it possible for this TSAN error to trigger, but it didn't trigger most of the time, so it was not detected in CI. There is also an [interaction](https://github.com/bitcoin-core/libmultiprocess/pull/286#issuecomment-4631871296) with #218 and #273 + #218 together make it much more likely to trigger 
