### PR TITLE
cmake: Skip `PATH` environment variable when discovering CapnProto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 include("cmake/compat_find.cmake")
 
 find_package(Threads REQUIRED)
-find_package(CapnProto 0.7 QUIET NO_MODULE)
+find_package(CapnProto 0.7 QUIET NO_MODULE NO_SYSTEM_ENVIRONMENT_PATH)
  if(NOT CapnProto_FOUND)
    message(FATAL_ERROR
      "Cap'n Proto is required but was not found.\n"


### PR DESCRIPTION
On systems with UsrMerge, the `PATH` environment variable can [cause](https://github.com/maflcko/bitcoin-core-nightly/issues/14#issuecomment-4632269615) CMake to produce include paths that contain root-level symlinks. The `capnp` compiler resolves paths lexically and fails to process them properly, resulting in a "no such directory" error.

Fixes https://github.com/maflcko/bitcoin-core-nightly/issues/14.

CI runs in Bitcoin Core repo: https://github.com/hebasto/bitcoin/actions/runs/27019344100/job/79742757484.