### PR TITLE
cmake: Add `mp_headers` custom target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,10 @@ configure_file(include/mp/config.h.in "${CMAKE_CURRENT_BINARY_DIR}/include/mp/co
 # Generated C++ Capn'Proto schema files
 capnp_generate_cpp(MP_PROXY_SRCS MP_PROXY_HDRS include/mp/proxy.capnp)
 set_source_files_properties("${MP_PROXY_SRCS}" PROPERTIES SKIP_LINTING TRUE) # Ignored before cmake 3.27
+# Build-graph node for generated headers. This lets targets that include
+# the headers order themselves after generation without depending on the
+# library target that also uses them.
+add_custom_target(mp_headers DEPENDS ${MP_PROXY_HDRS})
 
 # util library
 add_library(mputil OBJECT src/mp/util.cpp)


### PR DESCRIPTION
The new `mp_headers` target acts as a build-graph node for generated Cap'n Proto C++ headers. By providing this custom target, other targets that include the headers can properly order themselves after the generation step without needing to depend on the library target that also uses them.

This convenience target is necessary for proper build dependency management, as the underlying `capnp_generate_cpp` function is not [`CODEGEN`](https://cmake.org/cmake/help/latest/policy/CMP0171.html)-aware.

Required for https://github.com/bitcoin/bitcoin/pull/35468.