### PR TITLE
type-number: fix clang-tidy modernize-use-nullptr

### DIFF
--- a/include/mp/type-number.h
+++ b/include/mp/type-number.h
@@ -82,7 +82,7 @@ decltype(auto) CustomReadField(TypeList<LocalType>,
     InvokeContext& invoke_context,
     Input&& input,
     ReadDest&& read_dest,
-    typename std::enable_if<std::is_floating_point<LocalType>::value>::type* enable = 0)
+    typename std::enable_if<std::is_floating_point<LocalType>::value>::type* enable = nullptr)
 {
     auto value = input.get();
     static_assert(std::is_same<LocalType, decltype(value)>::value, "floating point type mismatch");


### PR DESCRIPTION
Prevent warning --modernize-use-nullptr when using clang-tidy on downstream projects (Noticed when pushing https://github.com/2140-dev/bitcoin/pull/42, this change was also necessary for https://github.com/bitcoin/bitcoin/pull/29409 so CI doens't error)