### PR TITLE
proxy-types: prevent race condition when reading client.m_context.connection

### DIFF
--- a/include/mp/proxy-types.h
+++ b/include/mp/proxy-types.h
@@ -655,7 +655,14 @@ struct CapRequestTraits<::capnp::Request<_Params, _Results>>
 template <typename Client>
 void clientDestroy(Client& client)
 {
-    if (client.m_context.connection) {
+    // Lock because m_context.connection can be cleared concurrently by the
+    // disconnect cleanup callback (see addSyncCleanup on ProxyClientBase constructor).
+    bool connected;
+    {
+        Lock lock{client.m_context.loop->m_mutex};
+        connected = client.m_context.connection != nullptr;
+    }
+    if (connected) {
         MP_LOG(*client.m_context.loop, Log::Debug) << "IPC client destroy " << CxxTypeName(client);
     } else {
         KJ_LOG(INFO, "IPC interrupted client destroy", CxxTypeName(client));


### PR DESCRIPTION
Fixes data race on reading m_context.connection in clientDestroy() in proxy-types.h.

The read was unsynchronized while the disconnect cleanup callback (registered with addSyncCleanup in the ProxyClientBase constructor) clears the same field under m_context.loop->m_mutex. When a ProxyClient is destroyed on the async cleanup thread while the connection is torn down on the event loop thread, the two accesses race. 

In practice the race is not harmfull because the value only selects a log message but it can fail the TSan build, which makes the CI fail.

The regression test added in 90be835 let the disconnect-during-cleanup path run, exposing the race under TSan.

Fix: lock m_context.loop->m_mutex around the read, matching the lock the disconnect callback already uses for the write.