### PR TITLE
Mark Waiter m_cv as guarded by m_mutex

### DIFF
--- a/include/mp/proxy-io.h
+++ b/include/mp/proxy-io.h
@@ -384,7 +384,7 @@ struct Waiter
     }
 
     template <class Predicate>
-    void wait(Lock& lock, Predicate pred)
+    void wait(Lock& lock, Predicate pred) MP_REQUIRES(m_mutex)
     {
         m_cv.wait(lock.m_lock, [&]() MP_REQUIRES(m_mutex) {
             // Important for this to be "while (m_fn)", not "if (m_fn)" to avoid
@@ -410,7 +410,7 @@ struct Waiter
     //! EventLoop::m_mutex as long as Waiter::mutex is locked first and
     //! EventLoop::m_mutex is locked second.
     Mutex m_mutex;
-    std::condition_variable m_cv;
+    std::condition_variable m_cv MP_GUARDED_BY(m_mutex);
     std::optional<kj::Function<void()>> m_fn MP_GUARDED_BY(m_mutex);
 };
 

--- a/test/mp/test/test.cpp
+++ b/test/mp/test/test.cpp
@@ -510,6 +510,7 @@ KJ_TEST("Make simultaneous IPC calls on single remote thread")
                 [&running, &tc, i](auto&& results) {
                     assert(results.getResult() == static_cast<int32_t>(100 * (i+1)));
                     running -= 1;
+                    Lock lock(tc.waiter->m_mutex);
                     tc.waiter->m_cv.notify_all();
                 }));
         }


### PR DESCRIPTION
This change fixes a lost wakeup bug in the "Make simultaneous IPC calls on single remote thread" test which is probably responsible for the hang reported https://github.com/bitcoin/bitcoin/issues/35491. The bug has existed since the test was introduced in 1238170f68e8fa7ae41c79465df5cdae34d568e9.

The change adds an `MP_GUARDED_BY(m_mutex)` annotation to `Waiter::m_cv`, and locks the mutex before notifying the condition variable in the test to satisfy the guarded-by requirement. 

Locking the mutex prevents a hang in the test that could happen because if there is no lock between the `running -= 1` state update and notifying the condition variable, there is no guarantee that the test is actively waiting on the condition variable when the notify call is made, so the notify might do nothing, and the test could wait forever.

(_edited by ryanofsky_)