### PR TITLE
ci: Bump channel to nixos-26.05

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      NIXPKGS_CHANNEL: nixos-25.05
+      NIXPKGS_CHANNEL: nixos-26.05
       NIX_EXTRA_CONFIG: |
         keep-env-derivations = true
         keep-outputs = true

--- a/ci/configs/olddeps.bash
+++ b/ci/configs/olddeps.bash
@@ -1,5 +1,8 @@
 CI_DESC="CI job using old Cap'n Proto and cmake versions"
 CI_DIR=build-olddeps
+# Pin olddeps to an older Nixpkgs channel, since compiling the old CMake
+# requires an older GCC.
+NIXPKGS_CHANNEL=nixos-25.05
 export CXXFLAGS="-Werror -Wall -Wextra -Wpedantic -Wno-unused-parameter -Wno-error=array-bounds"
 NIX_ARGS=(--argstr capnprotoVersion "0.7.1" --argstr cmakeVersion "3.12.4")
 BUILD_ARGS=(-k)


### PR DESCRIPTION
Mostly to get more recent iwyu coverage (ref https://github.com/bitcoin-core/libmultiprocess/pull/294#issuecomment-4669156136)