### PR TITLE
test: add map serialization round-trip coverage

### DIFF
--- a/test/mp/test/foo.capnp
+++ b/test/mp/test/foo.capnp
@@ -59,6 +59,7 @@ struct FooStruct $Proxy.wrap("mp::test::FooStruct") {
     optionalInt @3 :Int32 $Proxy.name("optional_int");
     hasOptionalInt @4 :Bool;
     unorderedSetInt @5 :List(Int32) $Proxy.name("unordered_set_int");
+    mapStringInt @6 :List(StringIntPair) $Proxy.name("map_string_int");
 }
 
 struct FooCustom $Proxy.wrap("mp::test::FooCustom") {
@@ -80,4 +81,9 @@ struct FooMutable {
 struct Pair(T1, T2) {
     first @0 :T1;
     second @1 :T2;
+}
+
+struct StringIntPair {
+    first @0 :Text;
+    second @1 :Int32;
 }

--- a/test/mp/test/foo.capnp
+++ b/test/mp/test/foo.capnp
@@ -55,7 +55,7 @@ interface FooFn $Proxy.wrap("ProxyCallback<std::function<int()>>") {
 struct FooStruct $Proxy.wrap("mp::test::FooStruct") {
     name @0 :Text;
     setInt @1 :List(Int32) $Proxy.name("set_int");
-    vBool @2 :List(Bool) $Proxy.name("v_bool");
+    vectorBool @2 :List(Bool) $Proxy.name("vector_bool");
     optionalInt @3 :Int32 $Proxy.name("optional_int");
     hasOptionalInt @4 :Bool;
     unorderedSetInt @5 :List(Int32) $Proxy.name("unordered_set_int");

--- a/test/mp/test/foo.h
+++ b/test/mp/test/foo.h
@@ -22,7 +22,7 @@ struct FooStruct
 {
     std::string name;
     std::set<int> set_int;
-    std::vector<bool> v_bool;
+    std::vector<bool> vector_bool;
     std::optional<int> optional_int;
     std::unordered_set<int> unordered_set_int;
     std::map<std::string, int> map_string_int;

--- a/test/mp/test/foo.h
+++ b/test/mp/test/foo.h
@@ -25,6 +25,7 @@ struct FooStruct
     std::vector<bool> v_bool;
     std::optional<int> optional_int;
     std::unordered_set<int> unordered_set_int;
+    std::map<std::string, int> map_string_int;
 };
 
 enum class FooEnum : uint8_t { ONE = 1, TWO = 2, };

--- a/test/mp/test/test.cpp
+++ b/test/mp/test/test.cpp
@@ -21,6 +21,7 @@
 #include <kj/debug.h>
 #include <kj/memory.h>
 #include <kj/test.h>
+#include <map>
 #include <memory>
 #include <mp/proxy.h>
 #include <mp/proxy.capnp.h>
@@ -150,6 +151,8 @@ KJ_TEST("Call FooInterface methods")
     in.v_bool.push_back(true);
     in.v_bool.push_back(false);
     in.optional_int = 3;
+    in.map_string_int.emplace("a", 1);
+    in.map_string_int.emplace("b", 2);
     FooStruct out = foo->pass(in);
     KJ_EXPECT(in.name == out.name);
     KJ_EXPECT(in.set_int.size() == out.set_int.size());
@@ -165,6 +168,11 @@ KJ_TEST("Call FooInterface methods")
         KJ_EXPECT(in.v_bool[i] == out.v_bool[i]);
     }
     KJ_EXPECT(in.optional_int == out.optional_int);
+    KJ_EXPECT(in.map_string_int.size() == out.map_string_int.size());
+    for (auto init{in.map_string_int.begin()}, outit{out.map_string_int.begin()}; init != in.map_string_int.end() && outit != out.map_string_int.end(); ++init, ++outit) {
+        KJ_EXPECT(init->first == outit->first);
+        KJ_EXPECT(init->second == outit->second);
+    }
 
     // Additional checks for std::optional member
     KJ_EXPECT(foo->pass(in).optional_int == 3);

--- a/test/mp/test/test.cpp
+++ b/test/mp/test/test.cpp
@@ -147,9 +147,9 @@ KJ_TEST("Call FooInterface methods")
     in.set_int.insert(1);
     in.unordered_set_int.insert(2);
     in.unordered_set_int.insert(1);
-    in.v_bool.push_back(false);
-    in.v_bool.push_back(true);
-    in.v_bool.push_back(false);
+    in.vector_bool.push_back(false);
+    in.vector_bool.push_back(true);
+    in.vector_bool.push_back(false);
     in.optional_int = 3;
     in.map_string_int.emplace("a", 1);
     in.map_string_int.emplace("b", 2);
@@ -163,9 +163,9 @@ KJ_TEST("Call FooInterface methods")
     for (const auto& elem : in.unordered_set_int) {
         KJ_EXPECT(out.unordered_set_int.count(elem) == 1);
     }
-    KJ_EXPECT(in.v_bool.size() == out.v_bool.size());
-    for (size_t i = 0; i < in.v_bool.size(); ++i) {
-        KJ_EXPECT(in.v_bool[i] == out.v_bool[i]);
+    KJ_EXPECT(in.vector_bool.size() == out.vector_bool.size());
+    for (size_t i = 0; i < in.vector_bool.size(); ++i) {
+        KJ_EXPECT(in.vector_bool[i] == out.vector_bool[i]);
     }
     KJ_EXPECT(in.optional_int == out.optional_int);
     KJ_EXPECT(in.map_string_int.size() == out.map_string_int.size());


### PR DESCRIPTION
Add test to ensure map serialization is working and will keep working. Useful for #285.

Also renames `v_bool` to `vector_bool`.

Best reviewed commit by commit.