### PR TITLE
type-chrono: Add CustomBuildField/CustomReadField overloads for std::chrono::time_point

### DIFF
--- a/include/mp/type-chrono.h
+++ b/include/mp/type-chrono.h
@@ -16,9 +16,9 @@ template <class Rep, class Period, typename Value, typename Output>
 void CustomBuildField(TypeList<std::chrono::duration<Rep, Period>>, Priority<1>, InvokeContext& invoke_context, Value&& value,
                       Output&& output)
 {
-    static_assert(std::numeric_limits<decltype(output.get())>::lowest() <= std::numeric_limits<Rep>::lowest(),
+    static_assert(safe_less_equal(std::numeric_limits<decltype(output.get())>::lowest(), std::numeric_limits<Rep>::lowest()),
                   "capnp type does not have enough range to hold lowest std::chrono::duration value");
-    static_assert(std::numeric_limits<decltype(output.get())>::max() >= std::numeric_limits<Rep>::max(),
+    static_assert(safe_greater_equal(std::numeric_limits<decltype(output.get())>::max(), std::numeric_limits<Rep>::max()),
                   "capnp type does not have enough range to hold highest std::chrono::duration value");
     output.set(value.count());
 }

--- a/include/mp/type-chrono.h
+++ b/include/mp/type-chrono.h
@@ -29,6 +29,29 @@ decltype(auto) CustomReadField(TypeList<std::chrono::duration<Rep, Period>>, Pri
 {
     return read_dest.construct(input.get());
 }
+
+//! Overload CustomBuildField and CustomReadField to serialize
+//! std::chrono::time_point parameters and return values as integer tick counts.
+//! The capnp field type must be an integer type with enough range to hold the
+//! time_since_epoch() count for the given Duration (e.g. Int64 for nanoseconds).
+template <class Clock, class Duration, typename Value, typename Output>
+void CustomBuildField(TypeList<std::chrono::time_point<Clock, Duration>>, Priority<1>, InvokeContext& invoke_context,
+                      Value&& value, Output&& output)
+{
+    using Rep = typename Duration::rep;
+    static_assert(safe_less_equal(std::numeric_limits<decltype(output.get())>::lowest(), std::numeric_limits<Rep>::lowest()),
+                  "capnp type does not have enough range to hold lowest std::chrono::time_point value");
+    static_assert(safe_greater_equal(std::numeric_limits<decltype(output.get())>::max(), std::numeric_limits<Rep>::max()),
+                  "capnp type does not have enough range to hold highest std::chrono::time_point value");
+    output.set(value.time_since_epoch().count());
+}
+
+template <class Clock, class Duration, typename Input, typename ReadDest>
+decltype(auto) CustomReadField(TypeList<std::chrono::time_point<Clock, Duration>>, Priority<1>,
+                               InvokeContext& invoke_context, Input&& input, ReadDest&& read_dest)
+{
+    return read_dest.construct(std::chrono::time_point<Clock, Duration>{Duration{input.get()}});
+}
 } // namespace mp
 
 #endif // MP_PROXY_TYPE_CHRONO_H

--- a/include/mp/type-number.h
+++ b/include/mp/type-number.h
@@ -6,6 +6,7 @@
 #define MP_PROXY_TYPE_NUMBER_H
 
 #include <mp/util.h>
+#include <utility>
 
 namespace mp {
 template <typename LocalType, typename Value>
@@ -16,7 +17,7 @@ LocalType BuildPrimitive(InvokeContext& invoke_context,
 {
     using E = std::make_unsigned_t<std::underlying_type_t<Value>>;
     using T = std::make_unsigned_t<LocalType>;
-    static_assert(std::numeric_limits<T>::max() >= std::numeric_limits<E>::max(), "mismatched integral/enum types");
+    static_assert(std::cmp_greater_equal(std::numeric_limits<T>::max(), std::numeric_limits<E>::max()), "mismatched integral/enum types");
     return static_cast<LocalType>(value);
 }
 
@@ -27,9 +28,9 @@ LocalType BuildPrimitive(InvokeContext& invoke_context,
     TypeList<LocalType>)
 {
     static_assert(
-        std::numeric_limits<LocalType>::lowest() <= std::numeric_limits<Value>::lowest(), "mismatched integral types");
+        std::cmp_less_equal(std::numeric_limits<LocalType>::lowest(), std::numeric_limits<Value>::lowest()), "mismatched integral types");
     static_assert(
-        std::numeric_limits<LocalType>::max() >= std::numeric_limits<Value>::max(), "mismatched integral types");
+        std::cmp_greater_equal(std::numeric_limits<LocalType>::max(), std::numeric_limits<Value>::max()), "mismatched integral types");
     return value;
 }
 

--- a/include/mp/type-number.h
+++ b/include/mp/type-number.h
@@ -21,7 +21,7 @@ LocalType BuildPrimitive(InvokeContext& invoke_context,
 }
 
 template <typename LocalType, typename Value>
-    requires std::is_integral_v<Value>
+    requires (std::is_integral_v<Value> && !std::is_same_v<std::remove_cv_t<Value>, bool>)
 LocalType BuildPrimitive(InvokeContext& invoke_context,
     const Value& value,
     TypeList<LocalType>)
@@ -30,6 +30,14 @@ LocalType BuildPrimitive(InvokeContext& invoke_context,
         std::numeric_limits<LocalType>::lowest() <= std::numeric_limits<Value>::lowest(), "mismatched integral types");
     static_assert(
         std::numeric_limits<LocalType>::max() >= std::numeric_limits<Value>::max(), "mismatched integral types");
+    return value;
+}
+
+template <typename LocalType>
+LocalType BuildPrimitive(InvokeContext& invoke_context, bool value, TypeList<LocalType>)
+{
+    static_assert(std::is_same_v<LocalType, bool>,
+        "capnp field type should be Bool for bool parameters. Fix the .capnp schema.");
     return value;
 }
 

--- a/include/mp/util.h
+++ b/include/mp/util.h
@@ -33,6 +33,21 @@ namespace mp {
 
 //! Generic utility functions used by capnp code.
 
+// std::cmp_less_equal/cmp_greater_equal only accept integer types (C++20 §[utility.intcmp]).
+// These wrappers fall back to regular comparison for floating-point types.
+template <typename A, typename B>
+constexpr bool safe_less_equal(A a, B b)
+{
+    if constexpr (std::is_floating_point_v<A> || std::is_floating_point_v<B>) return a <= b;
+    else return std::cmp_less_equal(a, b);
+}
+template <typename A, typename B>
+constexpr bool safe_greater_equal(A a, B b)
+{
+    if constexpr (std::is_floating_point_v<A> || std::is_floating_point_v<B>) return a >= b;
+    else return std::cmp_greater_equal(a, b);
+}
+
 //! Type holding a list of types.
 //!
 //! Example:


### PR DESCRIPTION
Needed for bitcoin/bitcoin#10102 since bitcoin/bitcoin#34882 was merged, which uses `NodeClock::time_point` in the `CNodeStats` struct (`m_last_send`, `m_last_recv`, `m_ping_start`) returned by `Node::getNodesStats`.