### PR TITLE
refactor: memcpy to std::ranges::copy to work around ubsan warn

### DIFF
--- a/include/mp/type-data.h
+++ b/include/mp/type-data.h
@@ -9,6 +9,7 @@
 
 #include <concepts>
 #include <span>
+#include <ranges>
 
 namespace mp {
 template <typename T, typename U>
@@ -33,7 +34,7 @@ requires (std::is_same_v<decltype(output.get()), ::capnp::Data::Builder> && IsBy
 {
     auto data = std::span{value};
     auto result = output.init(data.size());
-    memcpy(result.begin(), data.data(), data.size());
+    std::ranges::copy(data, result.begin());
 }
 
 template <typename LocalType, typename Input, typename ReadDest>

--- a/test/mp/test/foo.capnp
+++ b/test/mp/test/foo.capnp
@@ -27,6 +27,7 @@ interface FooInterface $Proxy.wrap("mp::test::FooImplementation") {
     callbackExtended @10 (context :Proxy.Context, callback :ExtendedCallback, arg: Int32) -> (result :Int32);
     passCustom @11 (arg :FooCustom) -> (result :FooCustom);
     passEmpty @12 (arg :FooEmpty) -> (result :FooEmpty);
+    passData @24 (arg :Data) -> (result :Data);
     passMessage @13 (arg :FooMessage) -> (result :FooMessage);
     passMutable @14 (arg :FooMutable) -> (arg :FooMutable);
     passEnum @15 (arg :Int32) -> (result :Int32);

--- a/test/mp/test/foo.h
+++ b/test/mp/test/foo.h
@@ -84,6 +84,7 @@ public:
     int callbackExtended(ExtendedCallback& callback, int arg) { return callback.callExtended(arg); }
     FooCustom passCustom(FooCustom foo) { return foo; }
     FooEmpty passEmpty(FooEmpty foo) { return foo; }
+    FooData passData(FooData foo) { return foo; }
     FooMessage passMessage(FooMessage foo) { foo.message += " call"; return foo; }
     void passMutable(FooMutable& foo) { foo.message += " call"; }
     FooEnum passEnum(FooEnum foo) { return foo; }

--- a/test/mp/test/test.cpp
+++ b/test/mp/test/test.cpp
@@ -239,6 +239,9 @@ KJ_TEST("Call FooInterface methods")
 
     foo->passEmpty(FooEmpty{});
 
+    FooData empty_data_out = foo->passData(FooData{});
+    KJ_EXPECT(empty_data_out.empty());
+
     FooMessage message1;
     message1.message = "init";
     FooMessage message2{foo->passMessage(message1)};


### PR DESCRIPTION
Using std::ranges::copy from the C++ standard library has a few benefits here:

* It has the additional benefit of being a bit more type safe and document any needed cast explicitly. (No cast is needed here)
* It has defined semantics for empty source ranges.


This should also fix https://github.com/bitcoin/bitcoin/pull/35118#discussion_r3506566815