### PR TITLE
bugfix: clear FD_CLOEXEC in child instead of parent before fork

### DIFF
--- a/src/mp/util.cpp
+++ b/src/mp/util.cpp
@@ -60,6 +60,18 @@ size_t MaxFd()
     }
 }
 
+//! Report an error and exit from the post-fork child of a multi-threaded
+//! process, where only async-signal-safe calls (like write and _exit) are
+//! allowed. Accepting only a reference to a char array (in practice a string
+//! literal) ensures no allocation is needed at the call site.
+template <std::size_t N>
+[[noreturn]] void ChildFail(const char (&msg)[N]) noexcept
+{
+    const ssize_t written = ::write(STDERR_FILENO, msg, N - 1);
+    (void)written;
+    _exit(126);
+}
+
 } // namespace
 
 std::string ThreadName(const char* exe_name)
@@ -147,10 +159,7 @@ std::tuple<ProcessId, SocketId> SpawnProcess(SpawnConnectInfoToArgsFn&& connect_
             (void)close(fds[1]);
             throw std::system_error(errno, std::system_category(), "close");
         }
-        static constexpr char msg[] = "SpawnProcess(child): close(fds[1]) failed\n";
-        const ssize_t writeResult = ::write(STDERR_FILENO, msg, sizeof(msg) - 1);
-        (void)writeResult;
-        _exit(126);
+        ChildFail("SpawnProcess(child): close(fds[1]) failed\n");
     }
 
     if (!pid) {

--- a/src/mp/util.cpp
+++ b/src/mp/util.cpp
@@ -142,11 +142,6 @@ std::tuple<ProcessId, SocketId> SpawnProcess(SpawnConnectInfoToArgsFn&& connect_
     const std::vector<std::string> args{connect_info_to_args(std::to_string(fds[0]))};
     const std::vector<char*> argv{MakeArgv(args)};
 
-    // Clear FD_CLOEXEC on fds[0] before forking so it survives exec in the child.
-    int fds0_flags;
-    KJ_SYSCALL(fds0_flags = fcntl(fds[0], F_GETFD));
-    KJ_SYSCALL(fcntl(fds[0], F_SETFD, fds0_flags & ~FD_CLOEXEC));
-
     ProcessId pid = fork();
     if (pid == -1) {
         throw std::system_error(errno, std::system_category(), "fork");
@@ -170,6 +165,16 @@ std::tuple<ProcessId, SocketId> SpawnProcess(SpawnConnectInfoToArgsFn&& connect_
             if (fd != fds[0]) {
                 close(fd);
             }
+        }
+
+        // Clear FD_CLOEXEC on socket 0 so it survives exec. Doing this here
+        // rather than in the parent before forking avoids a window where a
+        // concurrent fork in another thread would leak the descriptor into an
+        // unrelated child process (which would not clear it).
+        // fcntl is async-signal-safe.
+        const int fds0_flags = fcntl(fds[0], F_GETFD);
+        if (fds0_flags == -1 || fcntl(fds[0], F_SETFD, fds0_flags & ~FD_CLOEXEC) == -1) {
+            ChildFail("SpawnProcess(child): clearing FD_CLOEXEC failed\n");
         }
 
         execvp(argv[0], argv.data());


### PR DESCRIPTION
Commit 652934fb793743ab1bf962b90c7a7d6f6681c199 in #274 _sets_ `FD_CLOEXEC` in order "to ensure sockets are not leaked if processes are spawned". However it's _cleared_ too early, before forking. This PR clears it _after_ forking, but still before exec.

The first commit adds a helper for signal-safely emitting an error message, since the second commit also needs this.

The second commit and a code comment explain why it's unsafe to clear `FD_CLOEXEC` before fork. ryanofsky also described it:

> As I understand it, this race has always existed, and was not introduced in [652934f](https://github.com/bitcoin-core/libmultiprocess/commit/652934fb793743ab1bf962b90c7a7d6f6681c199). What [652934f](https://github.com/bitcoin-core/libmultiprocess/commit/652934fb793743ab1bf962b90c7a7d6f6681c199) did was start using `FD_CLOEXEC` which narrowed the race window, without completely closing it. This followup PR fixes the race more completely, but there is still a small race between creating the socketpair and applying the cause the CLOEXEC flags.
> 
> The race happens when a `SpawnProcess` call happens at the same time as a separate `fork` call in unrelated thread not using `SpawnProcess`. Because `SpawnProcess` creates a socket pair, if a separate `fork` happens in another thread, it could inherit the socket pair file descriptors and keep them open too long if it is not looping over them and closing them like `SpawnProcess` is. As I understand it this could result in `socketpair` connections staying open even after the `SpawnProcess` parent or child have closed them, so `onDisconnect` events might not be triggered, and resources might not be freed.




A test in https://github.com/Sjors/libmultiprocess/commit/1e1ff0397bf26b69c0c4b0dfffac4106490f482c demonstrates the issue, but is not included in the PR to keep things simple.

This should not be an actual problem in the way Bitcoin Core uses libmultiprocess today, but it may be with Windows and/or multiple connection support.