### PR TITLE
cmake: Fix stale codegen when mpgen binary changes

### DIFF
--- a/cmake/TargetCapnpSources.cmake
+++ b/cmake/TargetCapnpSources.cmake
@@ -83,7 +83,7 @@ function(target_capnp_sources target include_prefix)
     add_custom_command(
       OUTPUT ${capnp_file}.c++ ${capnp_file}.h ${capnp_file}.proxy-client.c++ ${capnp_file}.proxy-types.h ${capnp_file}.proxy-server.c++ ${capnp_file}.proxy-types.c++ ${capnp_file}.proxy.h
       COMMAND ${MPGEN_BINARY} ${CMAKE_CURRENT_SOURCE_DIR} ${include_prefix} ${CMAKE_CURRENT_SOURCE_DIR}/${capnp_file} ${TCS_IMPORT_PATHS} ${mp_include_dir}
-      DEPENDS ${capnp_file}
+      DEPENDS ${capnp_file} ${MPGEN_BINARY}
       VERBATIM
     )
     # Skip linting for capnp-generated files but keep it for mpgen-generated ones


### PR DESCRIPTION
Add MPGEN_BINARY to DEPENDS so target_capnp_sources() also rebuilds when mpgen binary changes. This prevents stale code gen when mpgen binary changes but capnp files don't.

I noticed this after seeing IWYU errors while building the examples, which were caused by stale generated code that no longer matched what the current mpgen produces.