### PR TITLE
ipc: Fix mpgen capnp tool path for vcpkg/Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,16 @@ target_link_libraries(mpgen PRIVATE CapnProto::capnp-rpc)
 target_link_libraries(mpgen PRIVATE CapnProto::capnpc)
 target_link_libraries(mpgen PRIVATE CapnProto::kj)
 target_link_libraries(mpgen PRIVATE Threads::Threads)
+# Use CAPNP_EXECUTABLE/CAPNPC_CXX_EXECUTABLE cmake variables set by
+# CapnProtoConfig.cmake rather than reading the CapnProto::capnp_tool
+# IMPORTED_LOCATION directly. On Debian/Ubuntu, IMPORTED_LOCATION is broken
+# by a multiarch cmake packaging bug (see
+# https://github.com/bitcoin-core/libmultiprocess/issues/328), but
+# CapnProtoConfig.cmake works around it by hardcoding the correct paths. On
+# other platforms the variables hold generator expressions that
+# target_compile_definitions evaluates correctly at generation time.
+target_compile_definitions(mpgen PRIVATE CAPNP_EXECUTABLE=\"${CAPNP_EXECUTABLE}\")
+target_compile_definitions(mpgen PRIVATE CAPNPC_CXX_EXECUTABLE=\"${CAPNPC_CXX_EXECUTABLE}\")
 set_target_properties(mpgen PROPERTIES
     INSTALL_RPATH_USE_LINK_PATH TRUE)
 set_target_properties(mpgen PROPERTIES

--- a/src/mp/gen.cpp
+++ b/src/mp/gen.cpp
@@ -272,7 +272,7 @@ static void Generate(kj::StringPtr src_prefix,
     if (p != std::string::npos) include_base.erase(p);
 
     std::vector<std::string> args;
-    args.emplace_back(capnp_PREFIX "/bin/capnp");
+    args.emplace_back(CAPNP_EXECUTABLE);
     args.emplace_back("compile");
     args.emplace_back("--src-prefix=");
     args.back().append(src_prefix.cStr(), src_prefix.size());
@@ -280,11 +280,11 @@ static void Generate(kj::StringPtr src_prefix,
         args.emplace_back("--import-path=");
         args.back().append(import_path.cStr(), import_path.size());
     }
-    args.emplace_back("--output=" capnp_PREFIX "/bin/capnpc-c++");
+    args.emplace_back("--output=" CAPNPC_CXX_EXECUTABLE);
     args.emplace_back(src_file);
     const int status = mp::WaitProcess(mp::StartProcess(args));
     if (status) {
-        throw std::runtime_error("Invoking " capnp_PREFIX "/bin/capnp failed");
+        throw std::runtime_error("Invoking " CAPNP_EXECUTABLE " failed");
     }
 
     const capnp::SchemaParser parser;


### PR DESCRIPTION
It seems that in the vcpkg capnproto package, the `capnp` code generator can't be found in `<capnp_PREFIX>/bin/capnp` but is in another path that needs to be read from the cmake configuration, so this change adds cmake code to handle that.

Unfortunately the previous code using `<capnp_PREFIX>/bin` can't be removed because the llbcapnp-dev 1.0.1 package in Ubuntu Noble is buggy and specifies the wrong executable path in its cmake information. (If this problem is fixed, the old `capnp_PREFIX` code could be dropped.)

This change is needed to get MSVC builds working in https://github.com/bitcoin/bitcoin/pull/32387