### PR TITLE
cmake: Remove `QUIET` option from `find_package(CapnProto ...)`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 include("cmake/compat_find.cmake")
 
 find_package(Threads REQUIRED)
-find_package(CapnProto 0.9 QUIET NO_MODULE)
+find_package(CapnProto 0.9 NO_MODULE)
  if(NOT CapnProto_FOUND)
    message(FATAL_ERROR
      "Cap'n Proto is required but was not found.\n"


### PR DESCRIPTION
Cap'n Proto's Autotools-installed package config forwards the `QUIET` option to its internal `find_package(PkgConfig)` call and, when `QUIET` is given, suppresses its own diagnostics. As a result, a missing `PkgConfig` (for example, with the system `capnproto` package on NetBSD) was indistinguishable from `capnproto` itself being absent:
```console
$ cmake -B build
-- The CXX compiler identification is GNU 12.5.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE
CMake Error at CMakeLists.txt:18 (message):
  Cap'n Proto is required but was not found.

  To resolve, choose one of the following:

    - Install Cap'n Proto (version 1.0+ recommended)
    - For Bitcoin Core compilation build with -DENABLE_IPC=OFF to disable multiprocess support



-- Configuring incomplete, errors occurred!
$ sudo pkgin install capnproto
Password:
calculating dependencies...done.

1 package to install:
  capnproto-1.4.0

0 to remove, 0 to refresh, 0 to upgrade, 1 to install
2652K to download, 21M of additional disk space will be used

proceed ? [Y/n] y
[1/1] capnproto-1.4.0.tgz                                                                                                                         100% 2652KB   2.6MB/s   00:01    
[1/1] installing capnproto-1.4.0...
pkg_install warnings: 0, errors: 0
reading local summary...
processing local summary...
$ cmake -B build --fresh
-- The CXX compiler identification is GNU 12.5.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE
CMake Error at CMakeLists.txt:18 (message):
  Cap'n Proto is required but was not found.

  To resolve, choose one of the following:

    - Install Cap'n Proto (version 1.0+ recommended)
    - For Bitcoin Core compilation build with -DENABLE_IPC=OFF to disable multiprocess support



-- Configuring incomplete, errors occurred!
```


Without `QUIET`, the actual cause can be diagnosed:
```console
$ cmake -B build --fresh
-- The CXX compiler identification is GNU 12.5.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE
-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE) 
CMake Warning at /usr/pkg/lib/cmake/CapnProto/CapnProtoTargets.cmake:40 (message):
  pkg-config cannot be found
Call Stack (most recent call first):
  /usr/pkg/lib/cmake/CapnProto/CapnProtoConfig.cmake:102 (include)
  CMakeLists.txt:16 (find_package)


CMake Warning at CMakeLists.txt:16 (find_package):
  Found package configuration file:

    /usr/pkg/lib/cmake/CapnProto/CapnProtoConfig.cmake

  but it set CapnProto_FOUND to FALSE so package "CapnProto" is considered to
  be NOT FOUND.


CMake Error at CMakeLists.txt:18 (message):
  Cap'n Proto is required but was not found.

  To resolve, choose one of the following:

    - Install Cap'n Proto (version 1.0+ recommended)
    - For Bitcoin Core compilation build with -DENABLE_IPC=OFF to disable multiprocess support



-- Configuring incomplete, errors occurred!
```